### PR TITLE
Always send 'formatVersion' when firing PATCH against WCA website

### DIFF
--- a/src/lib/api/wcaAPI.ts
+++ b/src/lib/api/wcaAPI.ts
@@ -64,7 +64,8 @@ export const saveWcifChanges = (
     (key) => previousWcif[key as keyof Competition] !== newWcif[key as keyof Competition]
   );
   if (keysDiff.length === 0) return Promise.resolve();
-  return patchWcif(newWcif.id, pick(newWcif, keysDiff));
+  const keysForPatch = ['formatVersion', ...keysDiff];
+  return patchWcif(newWcif.id, pick(newWcif, keysForPatch));
 };
 
 export const searchPersons = (query: string): Promise<WcaPersonSearchResult[]> =>

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -158,7 +158,8 @@ export const uploadCurrentWCIFChanges =
       return;
     }
 
-    const changes = pick(wcif, Array.from(changedKeys));
+    const keysForPatch = ['formatVersion', ...Array.from(changedKeys)];
+    const changes = pick(wcif, keysForPatch);
 
     dispatch(updateUploading(true));
     patchWcif(competitionId, changes)


### PR DESCRIPTION
If you don't send this, then the WCA website will not know which keys/schema of your WCIF to actually parse.