### PR TITLE
Restore recipe selection + Run Recipe on beta

### DIFF
--- a/src/components/RoundActionButtons.tsx
+++ b/src/components/RoundActionButtons.tsx
@@ -1,5 +1,10 @@
 import { type ActivityWithParent } from '../lib/domain/types';
+import { Recipes } from '../lib/recipes';
 import Button from '@mui/material/Button';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
 import { type Person } from '@wca/helpers';
 
 interface RoundActionButtonsProps {
@@ -9,6 +14,9 @@ interface RoundActionButtonsProps {
   activityCode: string;
   onConfigureAssignments: () => void;
   onGenerateAssignments: () => void;
+  recipeId: string;
+  onChangeRecipeId: (recipeId: string) => void;
+  onRunRecipe: () => void;
   onConfigureStationNumbers: (activityCode: string) => void;
   onConfigureGroups: () => void;
   onResetAll: () => void;
@@ -23,6 +31,9 @@ export const RoundActionButtons = ({
   activityCode,
   onConfigureAssignments,
   onGenerateAssignments,
+  recipeId,
+  onChangeRecipeId,
+  onRunRecipe,
   onConfigureStationNumbers,
   onConfigureGroups,
   onResetAll,
@@ -42,6 +53,22 @@ export const RoundActionButtons = ({
       <>
         <Button onClick={onConfigureAssignments}>Configure Assignments</Button>
         <Button onClick={onGenerateAssignments}>Assign Competitor and Judging Assignments</Button>
+        <FormControl size="small" sx={{ minWidth: 220, marginLeft: 2 }}>
+          <InputLabel id="recipe-select-label">Recipe</InputLabel>
+          <Select
+            labelId="recipe-select-label"
+            label="Recipe"
+            value={recipeId}
+            onChange={(e) => onChangeRecipeId(String(e.target.value))}
+          >
+            {Recipes.map((r) => (
+              <MenuItem key={r.id} value={r.id}>
+                {r.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button onClick={onRunRecipe}>Run Recipe</Button>
         <div style={{ display: 'flex', flex: 1 }} />
         <Button onClick={onConfigureGroups}>Configure Groups</Button>
         <Button color="error" onClick={onResetAll}>

--- a/src/lib/recipes/activities.ts
+++ b/src/lib/recipes/activities.ts
@@ -1,0 +1,62 @@
+import { Competition, parseActivityCode } from '@wca/helpers';
+import { findAllActivities } from 'wca-group-generators';
+import { activityCodeIsChild } from '../domain/activities/activityCode';
+import { AssignmentStep } from './types';
+
+const getBaseActivities = (
+  wcif: Competition,
+  base: AssignmentStep['props']['activities']['base'],
+  roundId: string
+) => {
+  const allActivities = findAllActivities(wcif);
+  const activitiesForRound = allActivities
+    .filter(
+      (activity) =>
+        activityCodeIsChild(roundId, activity.activityCode) && roundId !== activity.activityCode
+    )
+    .sort((a, b) => a.activityCode.localeCompare(b.activityCode));
+
+  switch (base) {
+    case 'all':
+      return activitiesForRound;
+    case 'even':
+      return activitiesForRound.filter(
+        ({ activityCode }) => (parseActivityCode(activityCode)?.groupNumber as number) % 2 === 0
+      );
+    case 'odd':
+      return activitiesForRound.filter(
+        ({ activityCode }) => (parseActivityCode(activityCode)?.groupNumber as number) % 2 === 1
+      );
+    default:
+      return activitiesForRound;
+  }
+};
+
+export const getActivities = (
+  wcif: Competition,
+  { base, activityIds, options = {} }: AssignmentStep['props']['activities'],
+  roundId: string
+) => {
+  const baseActivities = getBaseActivities(wcif, base, roundId);
+
+  if (activityIds) {
+    return baseActivities.filter((activity) => activityIds?.includes(activity.id));
+  }
+
+  let baseActivityCodes = [...new Set(baseActivities.map((activity) => activity.activityCode))];
+  let filteredBaseActivities = baseActivities;
+
+  if (options.tail) {
+    baseActivityCodes = baseActivityCodes.slice(0, -1);
+  }
+
+  if (options.head) {
+    baseActivityCodes = baseActivityCodes.slice(0, options.head);
+  }
+
+  filteredBaseActivities = filteredBaseActivities.filter((activity) =>
+    baseActivityCodes.includes(activity.activityCode)
+  );
+
+  return filteredBaseActivities;
+};

--- a/src/lib/recipes/clusters.ts
+++ b/src/lib/recipes/clusters.ts
@@ -1,0 +1,145 @@
+import { Competition, Event, Person, Round, parseActivityCode } from '@wca/helpers';
+import Assignments from '../../config/assignments';
+import { findGroupActivitiesByRound } from '../wcif/activities';
+import { acceptedRegistrations, personsShouldBeInRound } from '../domain/persons';
+import { ClusterDefinition } from './types';
+import { byPROrResult } from 'wca-group-generators';
+
+export const Filters = [
+  {
+    key: 'hasAssignmentInRound',
+    name: 'Has Assignment In Round',
+    type: 'select',
+    options: [
+      {
+        id: 'staff-*',
+        name: 'Staff Any',
+      },
+      ...Assignments,
+    ],
+    filter: (assignmentCode: string, activityIds: number[]) => (person: Person) =>
+      person.assignments?.some((assignment) => {
+        if (!activityIds.includes(assignment.activityId)) {
+          return false;
+        }
+
+        if (assignmentCode === 'staff-*') {
+          return assignment.assignmentCode.startsWith('staff-');
+        }
+
+        return assignment.assignmentCode === assignmentCode;
+      }),
+  },
+  {
+    key: 'doesNotHaveAssignmentInRound',
+    name: 'Does Not Have Assignment In Round',
+    type: 'select',
+    options: [
+      {
+        id: 'staff-*',
+        name: 'Staff Any',
+      },
+      ...Assignments,
+    ],
+    filter: (assignmentCode: string, activityIds: number[]) => (person: Person) =>
+      !person.assignments?.some((assignment) => {
+        if (!activityIds.includes(assignment.activityId)) {
+          return false;
+        }
+
+        if (assignmentCode === 'staff-*') {
+          return assignment.assignmentCode.startsWith('staff-');
+        }
+
+        return assignment.assignmentCode === assignmentCode;
+      }),
+  },
+  {
+    key: 'hasRole',
+    name: 'Has Role',
+    type: 'select-multiple',
+    options: [
+      {
+        id: 'delegate',
+        name: 'Delegate',
+      },
+      {
+        id: 'trainee-delegate',
+        name: 'Delegate',
+      },
+      {
+        id: 'organizer',
+        name: 'Organizer',
+      },
+      {
+        id: 'staff-.*',
+        name: 'Staff',
+      },
+    ],
+    filter: (roles: string[]) => (person: Person) =>
+      roles.some((role) => person.roles?.some((r) => new RegExp(role).test(r))),
+  },
+  {
+    key: 'isFirstTimer',
+    name: 'Is First Timer',
+    type: 'boolean',
+    filter: (isFirstTimer: boolean) => (person: Person) =>
+      isFirstTimer ? !person.wcaId : !!person.wcaId,
+  },
+];
+
+export const getBaseCluster = (
+  wcif: Competition,
+  base: ClusterDefinition['base'],
+  roundId: string
+) => {
+  switch (base) {
+    case 'personsInRound': {
+      const round = wcif.events.flatMap((e) => e.rounds).find((r) => r.id === roundId) as Round;
+      return personsShouldBeInRound(round)(acceptedRegistrations(wcif.persons));
+    }
+    default:
+      return wcif.persons;
+  }
+};
+
+export const sortCluster = (wcif: Competition, cluster: ClusterDefinition, persons: Person[], roundId: string) => {
+  if (!cluster.sort) {
+    return persons;
+  }
+
+  if (cluster.sort.by === 'speed') {
+    const { eventId, roundNumber } = parseActivityCode(roundId) as {
+      eventId: string;
+      roundNumber: number;
+    };
+    const event = wcif.events.find((e) => e.id === eventId) as Event;
+    const sortedPersons = persons.sort(byPROrResult(event, roundNumber));
+    return cluster.sort.direction === 'asc' ? sortedPersons : sortedPersons.reverse();
+  }
+
+  return persons;
+}
+
+
+export const getCluster = (wcif: Competition, cluster: ClusterDefinition, roundId: string) => {
+  const activityIds = findGroupActivitiesByRound(wcif, roundId).map((a) => a.id);
+
+  const baseCluster = getBaseCluster(wcif, cluster.base, roundId);
+
+  if (!cluster.filters?.length) {
+    return baseCluster;
+  }
+
+  const filteredCluster = cluster.filters.reduce((acc, { key, value }) => {
+    const filter = Filters.find((f) => f.key === key)?.filter;
+    if (!filter) {
+      throw new Error(`Filter ${key} not found`);
+    }
+
+    // @ts-expect-error filter typing depends on filter key/value pair
+    return acc.filter(filter(value, activityIds));
+  }, baseCluster);
+
+  return sortCluster(wcif, cluster, filteredCluster, roundId);
+};

--- a/src/lib/recipes/index.ts
+++ b/src/lib/recipes/index.ts
@@ -1,0 +1,5 @@
+export * from './activities';
+export * from './clusters';
+export * from './recipes';
+export * from './steps';
+export * from './types';

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -1,0 +1,71 @@
+import { ActivityCode, Competition, Event, EventId, Round, parseActivityCode } from '@wca/helpers';
+import { StepLibrary, fromDefaults } from './steps';
+import { RecipeConfig, RecipeDefinition, Step } from './types';
+
+export const Recipes: RecipeDefinition[] = [
+  {
+    id: 'balanced',
+    name: 'Balanced',
+    description: 'Balanced',
+    defaultSteps: [
+      StepLibrary.SpreadDelegates,
+      StepLibrary.BalancedCompetitorAssignmentsForEveryone,
+      StepLibrary.NoCompetitorAssignmentLeftBehind,
+      StepLibrary.GenerateJudgeAssignmentsForCompetitors,
+    ],
+  },
+  {
+    id: 'pnw',
+    name: 'PNW',
+    description: 'PNW',
+    defaultSteps: [
+      StepLibrary.GenerateCompetitorAssignmentsForStaff,
+      StepLibrary.GenerateCompetitorAssignmentsForFirstTimers,
+      StepLibrary.GenerateCompetitorAssignments,
+      StepLibrary.GenerateJudgeAssignmentsForCompetitors,
+    ],
+  },
+  {
+    id: '1-group-finals',
+    name: '1 group final',
+    description: 'Makes a single group of competitors for finals',
+    defaultSteps: [StepLibrary.GenerateSingleGroup, StepLibrary.GenerateCompetitorAssignments],
+  },
+  {
+    id: 'mca',
+    name: 'MCA',
+    description: 'MCA',
+    defaultSteps: [
+      StepLibrary.GenerateFirstTimersInSameGroup,
+      StepLibrary.SpreadDelegates,
+      StepLibrary.SpreadStaffAcrossGroups,
+      StepLibrary.BalancedCompetitorAssignmentsForEveryone,
+      StepLibrary.GenerateJudgeAssignmentsForCompetitors,
+    ],
+  },
+];
+
+export const fromRecipeDefinition = (
+  recipe: RecipeDefinition,
+  { wcif, activityCode }: { wcif: Competition; activityCode: ActivityCode }
+): RecipeConfig => ({
+  id: recipe.id,
+  name: recipe.name,
+  description: recipe.description,
+  steps: recipe.defaultSteps.map((step) => fromDefaults(step, { wcif, activityCode })) as Step[],
+});
+
+export const getPreferredDefaultRecipe = (wcif: Competition, round: Round) => {
+  const { eventId } = parseActivityCode(round.id) as { eventId: EventId; roundNumber: number };
+
+  const event = wcif.events.find((event) => event.id === eventId) as Event;
+
+  const rounds = event.rounds.map((round) => round.id).sort();
+
+  // Is last round?
+  if (rounds[rounds.length - 1] === round.id) {
+    return 'pnw-1-group-finals';
+  }
+
+  return 'pnw';
+};

--- a/src/lib/recipes/steps.ts
+++ b/src/lib/recipes/steps.ts
@@ -1,0 +1,41 @@
+import { ActivityCode, Competition } from '@wca/helpers';
+import { getActivities } from './activities';
+import { getCluster } from './clusters';
+import * as core from './steps/core';
+import * as mca from './steps/mca';
+import * as pnw from './steps/pnw';
+import { AssignmentStep, StepDefinition } from './types';
+
+export const StepLibrary: Record<string, StepDefinition> = {
+  GenerateSingleGroup: core.GenerateSingleGroup,
+  SpreadDelegates: core.SpreadDelegates,
+  BalancedCompetitorAssignmentsForEveryone: core.BalancedCompetitorAssignmentsForEveryone,
+  NoCompetitorAssignmentLeftBehind: core.NoCompetitorAssignmentLeftBehind,
+  GenerateCompetitorAssignmentsForStaff: pnw.GenerateCompetitorAssignmentsForStaff,
+  GenerateCompetitorAssignmentsForFirstTimers: pnw.GenerateCompetitorAssignmentsForFirstTimers,
+  GenerateCompetitorAssignments: pnw.GenerateCompetitorAssignments,
+  GenerateJudgeAssignmentsForCompetitors: pnw.GenerateJudgeAssignmentsForCompetitors,
+  GenerateFirstTimersInSameGroup: mca.GenerateFirstTimersInSameGroup,
+  SpreadStaffAcrossGroups: mca.SpreadStaffAcrossGroups,
+};
+
+export const Steps: StepDefinition[] = Object.keys(StepLibrary).map((key) => StepLibrary[key]);
+
+export const fromDefaults = (
+  step: StepDefinition,
+  { wcif, activityCode }: { wcif: Competition; activityCode: ActivityCode }
+) => ({
+  id: step.id,
+  ...step.defaults(wcif, activityCode),
+});
+
+export const hydrateStep = (wcif: Competition, roundId: string, step: AssignmentStep) => {
+  return {
+    ...step,
+    props: {
+      ...step.props,
+      cluster: getCluster(wcif, step.props.cluster, roundId),
+      activities: getActivities(wcif, step.props.activities, roundId),
+    },
+  };
+};

--- a/src/lib/recipes/steps/core.ts
+++ b/src/lib/recipes/steps/core.ts
@@ -1,0 +1,170 @@
+import { StepDefinition } from '../types';
+
+export const GenerateSingleGroup: StepDefinition = {
+  id: 'GenerateSingleGroup',
+  name: 'Generate Single Group',
+  description: 'Generates a single group of competitors',
+  defaults: () => ({
+    type: 'groups',
+    props: {
+      count: 1,
+    },
+  }),
+};
+
+export const SpreadDelegates: StepDefinition = {
+  id: 'SpreadDelegateCompetitorAssignments',
+  name: 'Spread Delegate Competitor Assignments',
+  description: 'Spreads delegates across groups',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'hasRole',
+            value: ['delegate', 'trainee-delegate'],
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'asc',
+        }
+      },
+      assignmentCode: 'competitor',
+      activities: { base: 'all' },
+      options: {
+        mode: 'symmetric',
+      },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'balancedGroupNumberSize',
+          weight: 2,
+          options: {
+            persons: 'cluster',
+          },
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: 1,
+          options: {
+            persons: 'cluster',
+          },
+        },
+      ],
+    },
+  }),
+};
+
+export const BalancedCompetitorAssignmentsForEveryone: StepDefinition = {
+  id: 'BalancedCompetitorAssignmentsForEveryone',
+  name: 'Balanced Competitor Assignments For Everyone',
+  description:
+    'Splits up the remaining people without competitor assignments and assigns groups by speed',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'doesNotHaveAssignmentInRound',
+            value: 'competitor',
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'desc',
+        }
+      },
+      assignmentCode: 'competitor',
+      activities: { base: 'all' },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveConflictingAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'groupBySpeed',
+          weight: 20,
+        },
+        {
+          constraint: 'restrictActivitySize',
+          weight: 1,
+          options: {
+            maxSize: 'average',
+          },
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: 1,
+        },
+      ],
+    },
+  }),
+};
+
+export const NoCompetitorAssignmentLeftBehind: StepDefinition = {
+  id: 'NoCompetitorAssignmentLeftBehind',
+  name: 'No Competitor Assignment Left Behind',
+  description:
+    'Assigns the remaining people without competitor assignments to a group',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'doesNotHaveAssignmentInRound',
+            value: 'competitor',
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'desc',
+        }
+      },
+      assignmentCode: 'competitor',
+      activities: { base: 'all' },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveConflictingAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: 1,
+        },
+      ],
+    },
+  }),
+};

--- a/src/lib/recipes/steps/mca.ts
+++ b/src/lib/recipes/steps/mca.ts
@@ -1,0 +1,116 @@
+import { parseActivityCode } from '@wca/helpers';
+import { findGroupActivitiesByRound } from '../../wcif/activities';
+import { StepDefinition } from '../types';
+
+export const GenerateFirstTimersInSameGroup: StepDefinition = {
+  id: 'GenerateFirstTimersInSameGroup',
+  name: 'Assign First Timers In The Same Group',
+  description: 'Assigns first timers to the same group',
+  defaults: (wcif, activityCode) => {
+    const groups = findGroupActivitiesByRound(wcif, activityCode);
+
+    // get activities that represent the first group
+    const activityIds = groups
+      .filter((g) => {
+        const parsedActivityCode = parseActivityCode(g.activityCode);
+        return parsedActivityCode.groupNumber === 1;
+      })
+      .map((group) => group.id);
+
+    return {
+      type: 'assignments',
+      props: {
+        generator: 'assignEveryone',
+        cluster: {
+          base: 'personsInRound',
+          filters: [
+            {
+              key: 'isFirstTimer',
+              value: true,
+            },
+          ],
+          sort: {
+            by: 'speed',
+            direction: 'asc',
+          },
+        },
+        assignmentCode: 'competitor',
+        activities: {
+          base: 'all',
+          activityIds,
+        },
+        constraints: [
+          {
+            constraint: 'uniqueAssignment',
+            weight: 1,
+          },
+          {
+            constraint: 'mustNotHaveOtherAssignments',
+            weight: 1,
+          },
+          {
+            constraint: 'balancedGroupSize',
+            weight: 1,
+          },
+        ],
+      },
+    };
+  },
+};
+
+export const SpreadStaffAcrossGroups: StepDefinition = {
+  id: 'SpreadStaffAcrossGroups',
+  name: 'Spread Staff Across Groups',
+  description: 'Spreads staff across groups',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'hasRole',
+            value: ['staff-.*'],
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'desc',
+        },
+      },
+      assignmentCode: 'competitor',
+      activities: { base: 'all' },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveConflictingAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'restrictActivitySize',
+          weight: 1,
+          options: {
+            maxClusterSize: 'average',
+          }
+        },
+        {
+          constraint: 'groupBySpeed',
+          weight: 20,
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: 1,
+          options: 'cluster',
+        },
+      ],
+    },
+  }),
+};

--- a/src/lib/recipes/steps/pnw.ts
+++ b/src/lib/recipes/steps/pnw.ts
@@ -1,0 +1,211 @@
+import { StepDefinition } from '../types';
+
+export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
+  id: 'GenerateCompetitorAssignmentsForStaff',
+  name: 'Generate Competitor Assignments For Staff',
+  description:
+    'Generates competitor assignments for staff members based on their staff assignments',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'hasAssignmentInRound',
+            value: 'staff-*',
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'asc',
+        },
+      },
+      assignmentCode: 'competitor',
+      activities: { base: 'all' },
+      options: {
+        mode: 'symmetric',
+      },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'sameStageAsOtherAssignments',
+          weight: 5,
+        },
+        {
+          constraint: 'maximizeBreaks',
+          weight: 10,
+        },
+        {
+          constraint: 'assignmentsNextToEachother',
+          weight: 2,
+        },
+        {
+          constraint: 'avoidConflictingNames',
+          weight: 10,
+        },
+      ],
+    },
+  }),
+};
+
+export const GenerateCompetitorAssignmentsForFirstTimers: StepDefinition = {
+  id: 'GenerateCompetitorAssignmentsForFirstTimers',
+  name: 'Generate Competitor Assignments For First Timers',
+  description: 'Generates competitor assignments for first timers',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'isFirstTimer',
+            value: true,
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'asc',
+        },
+      },
+      assignmentCode: 'competitor',
+      activities: { base: 'all', options: { tail: 1 } },
+      options: {
+        mode: 'symmetric',
+      },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'avoidConflictingNames',
+          weight: 1,
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: 1,
+        },
+      ],
+    },
+  }),
+};
+
+export const GenerateCompetitorAssignments: StepDefinition = {
+  id: 'GenerateCompetitorAssignments',
+  name: 'Generate Competitor Assignments',
+  description: 'Generates competitor assignments for everyone else',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'doesNotHaveAssignmentInRound',
+            value: 'competitor',
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'asc',
+        },
+      },
+      assignmentCode: 'competitor',
+      activities: { base: 'all' },
+      options: {
+        mode: 'symmetric',
+      },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'avoidConflictingNames',
+          weight: 10,
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: 5,
+        },
+        {
+          constraint: 'balancedSpeed',
+          weight: 5,
+        },
+      ],
+    },
+  }),
+};
+
+export const GenerateJudgeAssignmentsForCompetitors: StepDefinition = {
+  id: 'GenerateJudgeAssignmentsForCompetitors',
+  name: 'Generate Judge Assignments For Competitors',
+  description:
+    'Creates judge assignments for competitors based on their competitor assignments. Judge assignments are generally assigned for the group directly following the competitor assignment.',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      assignmentCode: 'staff-judge',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'hasAssignmentInRound',
+            value: 'competitor',
+          },
+          {
+            key: 'doesNotHaveAssignmentInRound',
+            value: 'staff-*',
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'asc',
+        },
+      },
+      activities: { base: 'all' },
+      options: {
+        mode: 'symmetric',
+      },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'sameStageAsOtherAssignments',
+          weight: 5,
+        },
+        {
+          constraint: 'shouldFollowCompetitorAssignment',
+          weight: 10,
+        },
+      ],
+    },
+  }),
+};

--- a/src/lib/recipes/types.ts
+++ b/src/lib/recipes/types.ts
@@ -1,0 +1,74 @@
+import { Competition } from '@wca/helpers';
+
+export interface ClusterFilter {
+  key: string;
+  value: string | string[] | number | boolean;
+}
+
+export interface ClusterDefinition {
+  base: string;
+  filters: ClusterFilter[];
+  sort?: {
+    by: 'speed';
+    direction: 'asc' | 'desc';
+  }
+}
+
+export interface ActivitiesDefinition {
+  base: 'all' | 'even' | 'odd';
+  options?: any;
+  /**
+   * Source of truth for activities. If provided, overrides `base` and `options`.
+   */
+  activityIds?: number[];
+}
+
+export interface ConstraintProps {
+  constraint: string;
+  weight: number;
+  options?: any;
+}
+
+export interface AssignmentStep {
+  id: string;
+  type: 'assignments';
+  props: {
+    generator: string;
+    assignmentCode: string;
+    cluster: ClusterDefinition;
+    activities: ActivitiesDefinition;
+    constraints: ConstraintProps[];
+    options?: any;
+  };
+}
+
+export interface GroupStep {
+  id: string;
+  type: 'groups';
+  props: {
+    count: number;
+  };
+}
+
+export type Step = GroupStep | AssignmentStep;
+
+export interface StepDefinition {
+  id: string;
+  name: string;
+  description: string;
+  defaults: (wcif: Competition, roundId: string) => Omit<Step, 'id'>;
+}
+
+export interface RecipeDefinition {
+  id: string;
+  name: string;
+  description: string;
+  defaultSteps: Array<StepDefinition>;
+}
+
+export interface RecipeConfig {
+  id: string;
+  name: string;
+  description: string;
+  steps: Array<Step>;
+}

--- a/src/pages/Competition/Round/RoundContainer.tsx
+++ b/src/pages/Competition/Round/RoundContainer.tsx
@@ -12,10 +12,14 @@ import { RoundStatisticsCard } from '../../../components/RoundStatisticsCard';
 import { useRoundActions } from './hooks/useRoundActions';
 import { useRoundData } from './hooks/useRoundData';
 import { useRoundDialogs } from './hooks/useRoundDialogs';
+import { getRoundConfigExtensionData } from '../../../lib/wcif/extensions/delegateDashboard/delegateDashboard';
+import { updateRoundExtensionData, runRecipe as runRecipeAction } from '../../../store/actions';
+import { useAppDispatch } from '../../../store';
 import { Alert, Typography } from '@mui/material';
 import Grid from '@mui/material/GridLegacy';
 import { type Round } from '@wca/helpers';
 import { ConfirmProvider } from 'material-ui-confirm';
+import { useState } from 'react';
 
 interface RoundContainerProps {
   roundId: string;
@@ -26,6 +30,7 @@ interface RoundContainerProps {
 
 const RoundContainer = ({ roundId, activityCode, eventId, round }: RoundContainerProps) => {
   const dialogs = useRoundDialogs();
+  const dispatch = useAppDispatch();
 
   const {
     wcif,
@@ -44,6 +49,19 @@ const RoundContainer = ({ roundId, activityCode, eventId, round }: RoundContaine
     groups,
     roundActivities,
   });
+
+  const existingRoundConfig = getRoundConfigExtensionData(round);
+  const existingRecipeId = (existingRoundConfig as any)?.recipe?.id as string | undefined;
+  const [recipeId, setRecipeId] = useState<string>(existingRecipeId ?? 'pnw');
+
+  const handleChangeRecipeId = (nextId: string) => {
+    setRecipeId(nextId);
+    dispatch(updateRoundExtensionData(round.id, { ...(existingRoundConfig ?? {}), recipe: { id: nextId } }));
+  };
+
+  const handleRunRecipe = () => {
+    dispatch(runRecipeAction(round.id, recipeId));
+  };
 
   if (roundActivities.length === 0) {
     return (
@@ -98,6 +116,9 @@ const RoundContainer = ({ roundId, activityCode, eventId, round }: RoundContaine
                 activityCode={activityCode}
                 onConfigureAssignments={() => dialogs.configureAssignments.setOpen(true)}
                 onGenerateAssignments={handleGenerateAssignments}
+                recipeId={recipeId}
+                onChangeRecipeId={handleChangeRecipeId}
+                onRunRecipe={handleRunRecipe}
                 onConfigureStationNumbers={(code) =>
                   dialogs.configureStationNumbers.setActivityCode(code)
                 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -46,6 +46,7 @@ export const ActionType = {
   PARTIAL_UPDATE_WCIF: 'partial_update_wcif',
   RESET_ALL_GROUP_ASSIGNMENTS: 'reset_all_group_assignments',
   GENERATE_ASSIGNMENTS: 'generate_assignments',
+  RUN_RECIPE: 'run_recipe',
   EDIT_ACTIVITY: 'edit_activity',
   UPDATE_GLOBAL_EXTENSION: 'update_global_extension',
   ADD_PERSON: 'add_person',
@@ -365,6 +366,20 @@ export type GenerateAssignmentsPayload = {
  * @param {ActivityCode} roundId
  * @returns
  */
+
+export type RunRecipePayload = {
+  roundId: string;
+  recipeId: string;
+};
+export const runRecipe = (
+  roundId: string,
+  recipeId: string
+): ReduxAction<typeof ActionType.RUN_RECIPE, RunRecipePayload> => ({
+  type: ActionType.RUN_RECIPE,
+  roundId,
+  recipeId,
+});
+
 export const generateAssignments = (
   roundId: string,
   options?: Partial<GenerateAssignmentsPayload['options']>

--- a/src/store/reducerHandlers.ts
+++ b/src/store/reducerHandlers.ts
@@ -170,6 +170,7 @@ export const reducers: Record<string, ReducerFunction> = {
     };
   },
   [ActionType.GENERATE_ASSIGNMENTS]: Reducers.generateAssignments,
+  [ActionType.RUN_RECIPE]: Reducers.runRecipe,
   [ActionType.EDIT_ACTIVITY]: (state, action: EditActivityPayload) => {
     if (!('where' in action && 'what' in action) || !state.wcif) return state;
     const { where, what } = action;

--- a/src/store/reducers/index.ts
+++ b/src/store/reducers/index.ts
@@ -1,3 +1,5 @@
 export * from './generateAssignments';
 export * from './competitorAssignments';
 export * from './persons';
+
+export * from './runRecipe';

--- a/src/store/reducers/runRecipe.ts
+++ b/src/store/reducers/runRecipe.ts
@@ -1,0 +1,84 @@
+import { type Competition } from '@wca/helpers';
+import { Constraints, Generators } from 'wca-group-generators';
+import { findRoundActivitiesById } from '../../lib/wcif/activities';
+import { createGroupsAcrossStages } from '../../lib/wcif/groups';
+import { Recipes, fromRecipeDefinition, hydrateStep } from '../../lib/recipes';
+import { mapIn } from '../../lib/utils/utils';
+import { type AppState } from '../initialState';
+import type { RunRecipePayload } from '../actions';
+
+/**
+ * Run a built-in recipe to generate groups and/or assignments for a round.
+ * Restores the legacy "recipe" workflow based on wca-group-generators.
+ */
+export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
+  if (!state.wcif) return state;
+
+  const wcif = state.wcif as unknown as Competition;
+  const recipeDef = Recipes.find((r) => r.id === action.recipeId);
+  if (!recipeDef) {
+    throw new Error(`Recipe ${action.recipeId} not found`);
+  }
+
+  const recipe = fromRecipeDefinition(recipeDef, { wcif, activityCode: action.roundId });
+
+  const updatedWcif = recipe.steps.reduce<Competition>((accWcif, step) => {
+    if (step.type === 'assignments') {
+      const generator = (Generators as Record<string, any>)[step.props.generator];
+      if (!generator) {
+        throw new Error(`Generator ${step.props.generator} not found`);
+      }
+
+      const hydratedStep = hydrateStep(accWcif, action.roundId, step);
+
+      const constraints =
+        hydratedStep.props.constraints?.map((c) => {
+          const constraintFn = (Constraints as Record<string, any>)[c.constraint];
+          if (!constraintFn) {
+            throw new Error(`Constraint ${c.constraint} not found`);
+          }
+          return {
+            constraint: constraintFn,
+            weight: c.weight,
+          };
+        }) ?? [];
+
+      return generator.execute({
+        wcif: accWcif,
+        roundId: action.roundId,
+        ...hydratedStep.props,
+        constraints,
+      }) as Competition;
+    }
+
+    if (step.type === 'groups') {
+      const roundActivities = findRoundActivitiesById(accWcif, action.roundId);
+      const roundActivitiesWithGroups = createGroupsAcrossStages(accWcif, roundActivities, {
+        spreadGroupsAcrossAllStages: true,
+        groups: step.props.count,
+      });
+
+      return {
+        ...accWcif,
+        schedule: mapIn(accWcif.schedule, 'venues', (venue) =>
+          mapIn(venue, 'rooms', (room) =>
+            mapIn(room, 'activities', (activity) =>
+              roundActivitiesWithGroups.find((ra) => ra.id === activity.id)
+                ? (roundActivitiesWithGroups.find((ra) => ra.id === activity.id) as any)
+                : activity
+            )
+          )
+        ),
+      } as Competition;
+    }
+
+    return accWcif;
+  }, wcif);
+
+  return {
+    ...state,
+    needToSave: true,
+    changedKeys: new Set([...state.changedKeys, 'schedule', 'persons', 'events']),
+    wcif: updatedWcif,
+  };
+}


### PR DESCRIPTION
Restores the legacy *recipe* workflow on the beta branch (select recipe + run), without bringing back the Recipe Editor UI.

- Reintroduces `src/lib/recipes/*` (steps + built-in recipes).
- Adds a `RUN_RECIPE` action + reducer that executes the recipe using wca-group-generators (groups/assignments).
- Adds Recipe dropdown + “Run Recipe” button on the round page action row.
- Persists selected recipe to round extension data (`roundConfig.recipe.id`).

Notes:
- Does **not** restore Recipe Editor dialogs/components (they were unused and had been breaking TS build).
- `yarn check:type` passes.
