### PR TITLE
Ignore schedule conflict warnings for cumulative time-limit rounds

### DIFF
--- a/src/lib/wcif/validation/personAssignmentValidation.test.ts
+++ b/src/lib/wcif/validation/personAssignmentValidation.test.ts
@@ -317,6 +317,76 @@ describe('validatePersonAssignmentScheduleConflicts', () => {
     expect(conflict?.assignmentA.room?.name).toBe('Room 1');
     expect(conflict?.assignmentB.room).toBeDefined();
   });
+
+  it('should not detect conflicts for overlapping assignments that share cumulative time limits', () => {
+    const wcif: Competition = {
+      ...mockWcif,
+      events: [
+        {
+          id: '444bf',
+          rounds: [
+            {
+              id: '444bf-r1',
+              timeLimit: { centiseconds: 360000, cumulativeRoundIds: ['444bf-r1', '555bf-r1'] },
+            },
+          ],
+        },
+        {
+          id: '555bf',
+          rounds: [
+            {
+              id: '555bf-r1',
+              timeLimit: { centiseconds: 360000, cumulativeRoundIds: ['444bf-r1', '555bf-r1'] },
+            },
+          ],
+        },
+      ] as Competition['events'],
+      schedule: {
+        ...mockWcif.schedule,
+        venues: [
+          {
+            ...mockWcif.schedule.venues[0],
+            rooms: [
+              {
+                ...mockWcif.schedule.venues[0].rooms[0],
+                activities: [
+                  {
+                    id: 11,
+                    name: '4BLD Round 1',
+                    activityCode: '444bf-r1',
+                    startTime: '2024-01-01T09:00:00.000Z',
+                    endTime: '2024-01-01T10:00:00.000Z',
+                    childActivities: [],
+                    extensions: [],
+                  },
+                  {
+                    id: 12,
+                    name: '5BLD Round 1',
+                    activityCode: '555bf-r1',
+                    startTime: '2024-01-01T09:00:00.000Z',
+                    endTime: '2024-01-01T10:00:00.000Z',
+                    childActivities: [],
+                    extensions: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      persons: [
+        createPerson({
+          assignments: [
+            { activityId: 11, stationNumber: null, assignmentCode: 'competitor' },
+            { activityId: 12, stationNumber: null, assignmentCode: 'staff-judge' },
+          ],
+        }),
+      ],
+    };
+
+    const errors = validatePersonAssignmentScheduleConflicts(wcif);
+    expect(errors).toHaveLength(0);
+  });
 });
 
 describe('validatePersonAssignments', () => {

--- a/src/lib/wcif/validation/personAssignmentValidation.ts
+++ b/src/lib/wcif/validation/personAssignmentValidation.ts
@@ -2,6 +2,7 @@ import {
   activitiesOverlap,
   findActivityById,
   findAllActivities,
+  parseActivityCode,
   roomByActivity,
 } from '../../domain';
 import { acceptedRegistrations } from '../../domain';
@@ -15,6 +16,48 @@ import type { Competition, Person } from '@wca/helpers';
 
 const pluralizeWord = (count: number, singular: string, plural?: string) =>
   count === 1 ? singular : plural || singular + 's';
+
+const roundsShareCumulativeTimeLimit = (
+  wcif: Competition,
+  activityIdA: number,
+  activityIdB: number
+) => {
+  const activityA = findActivityById(wcif, activityIdA);
+  const activityB = findActivityById(wcif, activityIdB);
+
+  if (!activityA || !activityB) {
+    return false;
+  }
+
+  const roundA = parseActivityCode(activityA.activityCode);
+  const roundB = parseActivityCode(activityB.activityCode);
+  if (
+    !roundA.eventId ||
+    !roundA.roundNumber ||
+    !roundB.eventId ||
+    !roundB.roundNumber ||
+    roundA.eventId === roundB.eventId
+  ) {
+    return false;
+  }
+
+  const eventA = wcif.events.find((event) => event.id === roundA.eventId);
+  const eventB = wcif.events.find((event) => event.id === roundB.eventId);
+  if (!eventA || !eventB) {
+    return false;
+  }
+
+  const roundAData = eventA.rounds?.find((round) => round.id === `${roundA.eventId}-r${roundA.roundNumber}`);
+  const roundBData = eventB.rounds?.find((round) => round.id === `${roundB.eventId}-r${roundB.roundNumber}`);
+  if (!roundAData?.timeLimit?.cumulativeRoundIds || !roundBData?.timeLimit?.cumulativeRoundIds) {
+    return false;
+  }
+
+  return (
+    roundAData.timeLimit.cumulativeRoundIds.includes(roundBData.id) &&
+    roundBData.timeLimit.cumulativeRoundIds.includes(roundAData.id)
+  );
+};
 
 /**
  * Validates that all person assignments reference existing activities
@@ -71,6 +114,10 @@ const findConflictingAssignmentsForPerson = (
       }
 
       if (!activitiesOverlap(activity, otherActivity)) {
+        return;
+      }
+
+      if (roundsShareCumulativeTimeLimit(wcif, assignment.activityId, otherAssignment.activityId)) {
         return;
       }
 


### PR DESCRIPTION
### Motivation
- Prevent false-positive schedule conflict warnings when two different events' rounds share a cumulative time limit and therefore are expected to run concurrently.

### Description
- Added `roundsShareCumulativeTimeLimit` helper in `src/lib/wcif/validation/personAssignmentValidation.ts` to detect when two activities belong to rounds that mutually list each other in `timeLimit.cumulativeRoundIds`.
- Skip reporting overlaps in `findConflictingAssignmentsForPerson` when `roundsShareCumulativeTimeLimit` returns `true` so assignments in such cumulative rounds do not generate conflicts.
- Added a regression test in `src/lib/wcif/validation/personAssignmentValidation.test.ts` that sets up two events/rounds (e.g., 4BLD/5BLD) with matching `cumulativeRoundIds` and overlapping times and asserts no conflict is produced.

### Testing
- Ran `npm run test -- src/lib/wcif/validation/personAssignmentValidation.test.ts` in this environment and it failed to execute because the `vitest` binary was not found in `PATH` (`sh: 1: vitest: not found`).
- No other automated test runs were performed in this environment, but a focused unit test covering the new behavior was added to `personAssignmentValidation.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0618a6fa5c8325bf181ae70799b402)