### PR TITLE
Include natshelper stage prefixes in nametag CSV export

### DIFF
--- a/src/pages/Competition/Export/index.tsx
+++ b/src/pages/Competition/Export/index.tsx
@@ -69,8 +69,15 @@ const groupNumber = ({ activityCode }: Pick<Activity, 'activityCode'>) =>
 const staffingAssignmentToText = ({ assignmentCode, activity }: AssignmentWithActivity) =>
   `${assignmentCode.split('-')[1][0].toUpperCase()}${groupNumber(activity)}`;
 
+const stagePrefixForNametags = (room: Room, activity: ActivityWithParent) => {
+  const stageName = getStageName(room, activity);
+  const stagePrefix = stageName.match(/[A-Za-z]+/)?.[0];
+
+  return stagePrefix || room.name[0];
+};
+
 const competingAssignmentToText = (activity: ActivityWithParent) =>
-  `${activity.parent.room.name[0]}${groupNumber(activity)}`;
+  `${stagePrefixForNametags(activity.parent.room, activity)}${groupNumber(activity)}`;
 
 const getStageName = (room: Room, activity: ActivityWithParent) => {
   const stages = getRoomExtensionData(room)?.stages;


### PR DESCRIPTION
### Motivation
- Ensure nametag CSV exports include stage-aware prefixes when a WCIF uses the natshelper extension so multi-stage assignments are exported correctly.

### Description
- Add a helper `stagePrefixForNametags` in `src/pages/Competition/Export/index.tsx` that derives a stage prefix from `natshelper` stage metadata and falls back to the room initial when unavailable. 
- Update `competingAssignmentToText` to use `stagePrefixForNametags` while leaving group-number formatting unchanged. 
- Change is limited to `src/pages/Competition/Export/index.tsx` and does not alter CSV column layout.

### Testing
- Ran `yarn check:type` which completed successfully. 
- Running `npm run check:type` failed in the container due to missing/incorrect `tsc` binary resolution in the environment and is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f773dd2e8832595d15de55e186eb1)