### PR TITLE
[codex] Add PNW recipe constraints

### DIFF
--- a/src/components/RoundActionButtons.tsx
+++ b/src/components/RoundActionButtons.tsx
@@ -13,7 +13,6 @@ interface RoundActionButtonsProps {
   personsShouldBeInRound: Person[];
   activityCode: string;
   onConfigureAssignments: () => void;
-  onGenerateAssignments: () => void;
   recipeId: string;
   onChangeRecipeId: (recipeId: string) => void;
   onRunRecipe: () => void;
@@ -30,7 +29,6 @@ export const RoundActionButtons = ({
   personsShouldBeInRound,
   activityCode,
   onConfigureAssignments,
-  onGenerateAssignments,
   recipeId,
   onChangeRecipeId,
   onRunRecipe,
@@ -52,7 +50,6 @@ export const RoundActionButtons = ({
     return (
       <>
         <Button onClick={onConfigureAssignments}>Configure Assignments</Button>
-        <Button onClick={onGenerateAssignments}>Assign Competitor and Judging Assignments</Button>
         <FormControl size="small" sx={{ minWidth: 220, marginLeft: 2 }}>
           <InputLabel id="recipe-select-label">Recipe</InputLabel>
           <Select
@@ -68,7 +65,7 @@ export const RoundActionButtons = ({
             ))}
           </Select>
         </FormControl>
-        <Button onClick={onRunRecipe}>Run Recipe</Button>
+        <Button onClick={onRunRecipe}>Generate</Button>
         <div style={{ display: 'flex', flex: 1 }} />
         <Button onClick={onConfigureGroups}>Configure Groups</Button>
         <Button color="error" onClick={onResetAll}>

--- a/src/components/RoundAssignmentCountsTable.tsx
+++ b/src/components/RoundAssignmentCountsTable.tsx
@@ -1,0 +1,164 @@
+import { AssignmentsMap } from '../config/assignments';
+import type { ActivityWithParent } from '../lib/domain/types';
+import {
+  Card,
+  CardHeader,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { parseActivityCode, type Person } from '@wca/helpers';
+
+const trackedAssignments = [
+  { assignmentCode: 'competitor', label: 'Competitor' },
+  { assignmentCode: 'staff-scrambler', label: 'Scrambler' },
+  { assignmentCode: 'staff-runner', label: 'Runner' },
+  { assignmentCode: 'staff-judge', label: 'Judge' },
+] as const;
+
+type TrackedAssignmentCode = (typeof trackedAssignments)[number]['assignmentCode'];
+
+type AssignmentCountRow = {
+  groupId: number;
+  stageName: string;
+  groupNumber: number | string;
+  counts: Record<TrackedAssignmentCode, number>;
+};
+
+type StageHeader = {
+  id: number;
+  name: string;
+  groups: AssignmentCountRow[];
+};
+
+const emptyCounts = () =>
+  trackedAssignments.reduce(
+    (counts, { assignmentCode }) => ({
+      ...counts,
+      [assignmentCode]: 0,
+    }),
+    {} as Record<TrackedAssignmentCode, number>
+  );
+
+const buildAssignmentCountRows = (
+  groups: ActivityWithParent[],
+  persons: Person[]
+): AssignmentCountRow[] =>
+  groups.map((group) => {
+    const counts = emptyCounts();
+    const groupAssignments = persons.flatMap((person) =>
+      (person.assignments ?? []).filter((assignment) => assignment.activityId === group.id)
+    );
+
+    for (const assignment of groupAssignments) {
+      if (assignment.assignmentCode in counts) {
+        counts[assignment.assignmentCode as TrackedAssignmentCode] += 1;
+      }
+    }
+
+    return {
+      groupId: group.id,
+      stageName: group.parent.room.name,
+      groupNumber: parseActivityCode(group.activityCode).groupNumber ?? '-',
+      counts,
+    };
+  });
+
+const buildStageHeaders = (rows: AssignmentCountRow[]) =>
+  rows.reduce<StageHeader[]>((headers, row) => {
+    const header = headers.find((candidate) => candidate.name === row.stageName);
+    if (header) {
+      header.groups.push(row);
+      return headers;
+    }
+
+    return [
+      ...headers,
+      {
+        id: row.groupId,
+        name: row.stageName,
+        groups: [row],
+      },
+    ];
+  }, []);
+
+interface RoundAssignmentCountsTableProps {
+  groups: ActivityWithParent[];
+  persons: Person[];
+}
+
+export const RoundAssignmentCountsTable = ({
+  groups,
+  persons,
+}: RoundAssignmentCountsTableProps) => {
+  const rows = buildAssignmentCountRows(groups, persons);
+  const stageHeaders = buildStageHeaders(rows);
+  const totalsByAssignment = rows.reduce((totalCounts, row) => {
+    for (const { assignmentCode } of trackedAssignments) {
+      totalCounts[assignmentCode] += row.counts[assignmentCode];
+    }
+
+    return totalCounts;
+  }, emptyCounts());
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader title="Assignment Counts" />
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell />
+              {stageHeaders.map((stage) => (
+                <TableCell
+                  key={stage.id}
+                  align="center"
+                  colSpan={stage.groups.length}
+                  sx={{ fontWeight: 600 }}>
+                  {stage.name}
+                </TableCell>
+              ))}
+              <TableCell />
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Assignment</TableCell>
+              {rows.map((row) => (
+                <TableCell key={row.groupId} align="center" sx={{ fontWeight: 600 }}>
+                  g{row.groupNumber}
+                </TableCell>
+              ))}
+              <TableCell align="right" sx={{ fontWeight: 600 }}>
+                Total
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {trackedAssignments.map(({ assignmentCode, label }) => (
+              <TableRow
+                key={assignmentCode}
+                sx={{ backgroundColor: alpha(AssignmentsMap[assignmentCode].color[200], 0.5) }}>
+                <TableCell sx={{ fontWeight: 600 }}>{label}</TableCell>
+                {rows.map((row) => (
+                  <TableCell key={row.groupId} align="center">
+                    {row.counts[assignmentCode]}
+                  </TableCell>
+                ))}
+                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                  {totalsByAssignment[assignmentCode]}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Card>
+  );
+};

--- a/src/components/_tests_/Header.test.tsx
+++ b/src/components/_tests_/Header.test.tsx
@@ -3,6 +3,7 @@ import { DrawerLinks, CompetitionHeader } from '../../layout/CompetitionLayout/C
 import { renderWithProviders } from '../../test-utils';
 import userEvent from '@testing-library/user-event';
 import type { AppState } from '../../store/initialState';
+import { buildEvent, buildRound } from '../../store/reducers/_tests_/helpers';
 
 const useAppSelector = vi.fn();
 
@@ -27,8 +28,23 @@ describe('Header', () => {
 });
 
 describe('DrawerLinks', () => {
+  const state = {
+    wcif: {
+      id: 'TestComp',
+      events: [
+        buildEvent({
+          id: '333',
+          rounds: [buildRound({ id: '333-r1' }), buildRound({ id: '333-r2' })],
+        }),
+        buildEvent({
+          id: '222',
+          rounds: [buildRound({ id: '222-r1' })],
+        }),
+      ],
+    },
+  } as unknown as AppState;
+
   it('renders menu links for the current competition', () => {
-    const state = { wcif: { id: 'TestComp' } } as unknown as AppState;
     useAppSelector.mockImplementation((selector: (state: AppState) => unknown) => selector(state));
 
     const { getByText, getByRole } = renderWithProviders(<DrawerLinks />);
@@ -40,5 +56,32 @@ describe('DrawerLinks', () => {
       'href',
       '/competitions/TestComp/assignments'
     );
+  });
+
+  it('renders event accordions with round links', async () => {
+    useAppSelector.mockImplementation((selector: (state: AppState) => unknown) => selector(state));
+
+    const { getByRole, getAllByRole } = renderWithProviders(<DrawerLinks />);
+
+    expect(getByRole('button', { name: /3x3x3 Cube/ })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(getByRole('button', { name: /2x2x2 Cube/ })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+
+    await userEvent.click(getByRole('button', { name: /2x2x2 Cube/ }));
+
+    expect(getByRole('button', { name: /2x2x2 Cube/ })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(
+      getAllByRole('link', { name: 'Round 1' }).some(
+        (link) => link.getAttribute('href') === '/competitions/TestComp/events/222-r1'
+      )
+    ).toBe(true);
   });
 });

--- a/src/dialogs/ConfigureAssignmentsDialog/ConfigureAssignmentsDialog.tsx
+++ b/src/dialogs/ConfigureAssignmentsDialog/ConfigureAssignmentsDialog.tsx
@@ -39,6 +39,7 @@ const ConfigureAssignmentsDialog = ({
   groups,
   isDistributedAttemptRoundLevel,
   distributedAttemptGroups,
+  defaultShowAllCompetitors,
 }: {
   open: boolean;
   onClose: () => void;
@@ -50,6 +51,7 @@ const ConfigureAssignmentsDialog = ({
     attemptNumber: number;
     activities: ActivityWithRoom[];
   }>;
+  defaultShowAllCompetitors?: boolean;
 }) => {
   const wcif = useAppSelector((state) => state.wcif);
   const { eventId, roundNumber } = parseActivityCode(activityCode) as {
@@ -63,7 +65,9 @@ const ConfigureAssignmentsDialog = ({
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-  const [showAllCompetitors, setShowAllCompetitors] = useState(isDistributedAttemptRoundLevel);
+  const [showAllCompetitors, setShowAllCompetitors] = useState(
+    defaultShowAllCompetitors ?? isDistributedAttemptRoundLevel
+  );
   const [paintingAssignmentCode, setPaintingAssignmentCode] = useState('staff-scrambler');
   const [competitorSort, setCompetitorSort] = useState<CompetitorSort>('speed');
   const [showCompetitorsNotInRound, setShowCompetitorsNotInRound] = useState(false);

--- a/src/dialogs/ConfigureGroupCountsDialog.tsx
+++ b/src/dialogs/ConfigureGroupCountsDialog.tsx
@@ -23,7 +23,7 @@ import {
   Typography,
 } from '@mui/material';
 import { type Activity, type Round, type Room } from '@wca/helpers';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 export interface ConfigureGroupCountsDialogProps {
@@ -48,6 +48,7 @@ const ConfigureGroupCountsDialog = ({
       .filter((room) => room.activities.find((a) => a.activityCode === activityCode))
   );
   const dispatch = useDispatch();
+  const groupCountInputRef = useRef<HTMLInputElement>(null);
   const groupsExtData = getGroupsExtensionData(round);
   const [groupsData, setGroupsData] = useState<{
     groups: number | Record<number, number>;
@@ -178,6 +179,8 @@ const ConfigureGroupCountsDialog = ({
                 <Input
                   id="groups"
                   type="number"
+                  autoFocus
+                  inputRef={groupCountInputRef}
                   value={groupCount || 1}
                   onChange={handleGroupsChange}
                 />

--- a/src/layout/CompetitionLayout/CompetitionHeader.tsx
+++ b/src/layout/CompetitionLayout/CompetitionHeader.tsx
@@ -1,5 +1,6 @@
 import { useAppSelector } from '../../store';
 import { Tune } from '@mui/icons-material';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import FileUploadIcon from '@mui/icons-material/FileUpload';
 import HomeIcon from '@mui/icons-material/Home';
@@ -102,6 +103,11 @@ export const DrawerLinks = () => {
           url: `/competitions/${competitionId}/scrambler-schedule`,
           icon: <ScheduleIcon />,
           text: 'Scrambler Schedule',
+        },
+        {
+          url: `/competitions/${competitionId}/bulk-generation`,
+          icon: <AutoFixHighIcon />,
+          text: 'Bulk Generate',
         },
         {
           type: 'divider' as const,

--- a/src/layout/CompetitionLayout/CompetitionHeader.tsx
+++ b/src/layout/CompetitionLayout/CompetitionHeader.tsx
@@ -1,4 +1,5 @@
 import { useAppSelector } from '../../store';
+import { EventRoundTree } from './EventRoundTree';
 import { Tune } from '@mui/icons-material';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
@@ -12,6 +13,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import {
   AppBar as MuiAppBar,
+  Box,
   Divider,
   IconButton,
   List,
@@ -109,9 +111,8 @@ export const DrawerLinks = () => {
           icon: <AutoFixHighIcon />,
           text: 'Bulk Generate',
         },
-        {
-          type: 'divider' as const,
-        },
+      ] as MenuItemOrDivider[],
+      data: [
         {
           url: `/competitions/${competitionId}/import`,
           icon: <FileUploadIcon />,
@@ -121,9 +122,6 @@ export const DrawerLinks = () => {
           url: `/competitions/${competitionId}/export`,
           icon: <FileDownloadIcon />,
           text: 'Export Data',
-        },
-        {
-          type: 'divider' as const,
         },
         {
           url: `/competitions/${competitionId}/checks/first-timers`,
@@ -160,14 +158,26 @@ export const DrawerLinks = () => {
     );
 
   return (
-    <List style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {menuLinks.top.map(renderLinkOrDivider)}
+    <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+      <List disablePadding sx={{ flexShrink: 0 }}>
+        {menuLinks.top.map(renderLinkOrDivider)}
+      </List>
+
       <Divider />
-      <div style={{ display: 'flex', flex: 1 }} />
+
+      <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+        <EventRoundTree />
+      </Box>
+
       <Divider />
-      <ListSubheader>Debug</ListSubheader>
-      {menuLinks.debug.map(renderLinkOrDivider)}
-    </List>
+
+      <List disablePadding sx={{ flexShrink: 0 }}>
+        {menuLinks.data.map(renderLinkOrDivider)}
+        <Divider />
+        <ListSubheader>Debug</ListSubheader>
+        {menuLinks.debug.map(renderLinkOrDivider)}
+      </List>
+    </Box>
   );
 };
 

--- a/src/layout/CompetitionLayout/CompetitionLayout.tsx
+++ b/src/layout/CompetitionLayout/CompetitionLayout.tsx
@@ -142,6 +142,8 @@ export const CompetitionLayout = () => {
           '& .MuiDrawer-paper': {
             width: drawerWidth,
             boxSizing: 'border-box',
+            display: 'flex',
+            flexDirection: 'column',
           },
         }}>
         <DrawerHeader>

--- a/src/layout/CompetitionLayout/EventRoundTree.tsx
+++ b/src/layout/CompetitionLayout/EventRoundTree.tsx
@@ -1,0 +1,114 @@
+import { activityCodeToName, parseActivityCode } from '../../lib/domain/activities';
+import { eventNameById } from '../../lib/domain/events';
+import { useAppSelector } from '../../store';
+import '@cubing/icons';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import { Link as RouterLink, useParams } from 'react-router-dom';
+
+const roundNameFor = (roundId: string) => {
+  const { roundNumber } = parseActivityCode(roundId);
+  return roundNumber ? `Round ${roundNumber}` : activityCodeToName(roundId);
+};
+
+export const EventRoundTree = () => {
+  const wcif = useAppSelector((state) => state.wcif);
+  const { competitionId, roundId } = useParams<{
+    competitionId: string;
+    roundId?: string;
+  }>();
+  const events = wcif?.events ?? [];
+
+  const selectedActivity = roundId ? parseActivityCode(roundId) : undefined;
+  const selectedEventId = selectedActivity?.eventId;
+  const firstEventId = events[0]?.id;
+  const [expandedEventId, setExpandedEventId] = useState<string | false>(
+    selectedEventId ?? firstEventId ?? false
+  );
+
+  useEffect(() => {
+    if (selectedEventId) {
+      setExpandedEventId(selectedEventId);
+      return;
+    }
+
+    if (firstEventId) {
+      setExpandedEventId((currentEventId) => currentEventId || firstEventId);
+    }
+  }, [firstEventId, selectedEventId]);
+
+  const eventsWithRounds = events.filter((event) => event.rounds.length > 0);
+
+  if (!wcif || eventsWithRounds.length === 0) {
+    return null;
+  }
+
+  return (
+    <List
+      dense
+      sx={{
+        py: 0,
+        '& .MuiAccordion-root:before': { display: 'none' },
+      }}>
+      {eventsWithRounds.map((event) => (
+        <Accordion
+          key={event.id}
+          disableGutters
+          elevation={0}
+          square
+          expanded={expandedEventId === event.id}
+          onChange={(_, expanded) => setExpandedEventId(expanded ? event.id : false)}>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls={`${event.id}-rounds-content`}
+            id={`${event.id}-rounds-header`}
+            sx={{
+              minHeight: 40,
+              px: 2,
+              '& .MuiAccordionSummary-content': {
+                alignItems: 'center',
+                gap: 1.5,
+                my: 0.75,
+                minWidth: 0,
+              },
+            }}>
+            <span className={`cubing-icon event-${event.id}`} />
+            <Typography variant="body2" noWrap>
+              {eventNameById(event.id)}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ p: 0 }}>
+            <List dense disablePadding>
+              {event.rounds.map((round) => (
+                <ListItemButton
+                  key={round.id}
+                  component={RouterLink}
+                  to={`/competitions/${competitionId ?? wcif.id}/events/${round.id}`}
+                  selected={
+                    selectedActivity?.eventId === event.id &&
+                    selectedActivity.roundNumber === parseActivityCode(round.id).roundNumber
+                  }
+                  sx={{ pl: 5 }}>
+                  <ListItemIcon sx={{ minWidth: 28 }}>
+                    <span className={`cubing-icon event-${event.id}`} />
+                  </ListItemIcon>
+                  <ListItemText primary={roundNameFor(round.id)} />
+                </ListItemButton>
+              ))}
+            </List>
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </List>
+  );
+};

--- a/src/layout/CompetitionLayout/_tests_/CompetitionLayout.test.tsx
+++ b/src/layout/CompetitionLayout/_tests_/CompetitionLayout.test.tsx
@@ -73,6 +73,13 @@ describe('CompetitionLayout', () => {
     expect(getByText('Child Content')).toBeInTheDocument();
   });
 
+  it('renders the bulk generation navigation link', () => {
+    getLocalStorageMock.mockReturnValue('true');
+    const { getByText } = renderLayout();
+
+    expect(getByText('Bulk Generate')).toBeInTheDocument();
+  });
+
   it('dispatches fetchWCIF on mount', () => {
     renderLayout();
 

--- a/src/layout/RootLayout/Navigation.tsx
+++ b/src/layout/RootLayout/Navigation.tsx
@@ -10,6 +10,7 @@ import {
   Export as ExportPage,
   Import as ImportPage,
   ScramblerSchedule as ScramblerSchedulePage,
+  BulkGeneration as BulkGenerationPage,
 } from '../../pages/Competition';
 import FirstTimers from '../../pages/Competition/Checks/FirstTimers';
 import DangerEditPage from '../../pages/Competition/DangerEdit/DangerEdit';
@@ -63,6 +64,7 @@ const Navigation = () => {
             <Route path="export" element={<ExportPage />} />
             <Route path="import" element={<ImportPage />} />
             <Route path="scrambler-schedule" element={<ScramblerSchedulePage />} />
+            <Route path="bulk-generation" element={<BulkGenerationPage />} />
             <Route path="query" element={<QueryPage />} />
             <Route path="checks/first-timers" element={<FirstTimers />} />
             <Route path="external/groupifier-printing" element={<GroupifierPrintingConfig />} />

--- a/src/lib/recipes/bulkGenerationDiagnostics.test.ts
+++ b/src/lib/recipes/bulkGenerationDiagnostics.test.ts
@@ -60,4 +60,133 @@ describe('bulkGenerationDiagnostics', () => {
 
     expect(countPeopleWithImmediateHelpingThenCompetingAssignments(wcif)).toBe(1);
   });
+
+  it('excludes immediate help then compete assignments within two-group rounds', () => {
+    const wcif = buildWcif(
+      [
+        buildActivity({
+          id: 1,
+          activityCode: '333-r1',
+          startTime: '2024-01-01T10:00:00Z',
+          endTime: '2024-01-01T10:30:00Z',
+          childActivities: [
+            buildActivity({
+              id: 101,
+              activityCode: '333-r1-g1',
+              startTime: '2024-01-01T10:00:00Z',
+              endTime: '2024-01-01T10:15:00Z',
+            }),
+            buildActivity({
+              id: 102,
+              activityCode: '333-r1-g2',
+              startTime: '2024-01-01T10:15:00Z',
+              endTime: '2024-01-01T10:30:00Z',
+            }),
+          ],
+        }),
+        buildActivity({
+          id: 2,
+          activityCode: '222-r1',
+          startTime: '2024-01-01T11:00:00Z',
+          endTime: '2024-01-01T11:45:00Z',
+          childActivities: [
+            buildActivity({
+              id: 201,
+              activityCode: '222-r1-g1',
+              startTime: '2024-01-01T11:00:00Z',
+              endTime: '2024-01-01T11:15:00Z',
+            }),
+            buildActivity({
+              id: 202,
+              activityCode: '222-r1-g2',
+              startTime: '2024-01-01T11:15:00Z',
+              endTime: '2024-01-01T11:30:00Z',
+            }),
+            buildActivity({
+              id: 203,
+              activityCode: '222-r1-g3',
+              startTime: '2024-01-01T11:30:00Z',
+              endTime: '2024-01-01T11:45:00Z',
+            }),
+          ],
+        }),
+      ],
+      [
+        buildPerson({
+          registrantId: 1,
+          assignments: [
+            { activityId: 101, assignmentCode: 'staff-judge', stationNumber: null },
+            { activityId: 102, assignmentCode: 'competitor', stationNumber: null },
+          ],
+        }),
+        buildPerson({
+          registrantId: 2,
+          assignments: [
+            { activityId: 201, assignmentCode: 'staff-judge', stationNumber: null },
+            { activityId: 202, assignmentCode: 'competitor', stationNumber: null },
+          ],
+        }),
+      ]
+    );
+
+    expect(countPeopleWithImmediateHelpingThenCompetingAssignments(wcif)).toBe(1);
+  });
+
+  it('counts unique group numbers when excluding two-group rounds across multiple stages', () => {
+    const wcif = buildWcif(
+      [
+        buildActivity({
+          id: 1,
+          activityCode: 'clock-r1',
+          startTime: '2024-01-01T10:00:00Z',
+          endTime: '2024-01-01T10:30:00Z',
+          childActivities: [
+            buildActivity({
+              id: 101,
+              activityCode: 'clock-r1-g1',
+              startTime: '2024-01-01T10:00:00Z',
+              endTime: '2024-01-01T10:15:00Z',
+            }),
+            buildActivity({
+              id: 102,
+              activityCode: 'clock-r1-g2',
+              startTime: '2024-01-01T10:15:00Z',
+              endTime: '2024-01-01T10:30:00Z',
+            }),
+          ],
+        }),
+        buildActivity({
+          id: 2,
+          activityCode: 'clock-r1',
+          startTime: '2024-01-01T10:00:00Z',
+          endTime: '2024-01-01T10:30:00Z',
+          childActivities: [
+            buildActivity({
+              id: 201,
+              activityCode: 'clock-r1-g1',
+              startTime: '2024-01-01T10:00:00Z',
+              endTime: '2024-01-01T10:15:00Z',
+            }),
+            buildActivity({
+              id: 202,
+              activityCode: 'clock-r1-g2',
+              startTime: '2024-01-01T10:15:00Z',
+              endTime: '2024-01-01T10:30:00Z',
+            }),
+          ],
+        }),
+      ],
+      [
+        buildPerson({
+          registrantId: 1,
+          assignments: [
+            { activityId: 101, assignmentCode: 'staff-judge', stationNumber: null },
+            { activityId: 102, assignmentCode: 'competitor', stationNumber: null },
+          ],
+        }),
+      ]
+    );
+
+    expect(countPeopleWithImmediateHelpingThenCompetingAssignments(wcif)).toBe(0);
+  });
 });

--- a/src/lib/recipes/bulkGenerationDiagnostics.test.ts
+++ b/src/lib/recipes/bulkGenerationDiagnostics.test.ts
@@ -1,0 +1,63 @@
+import { buildActivity, buildPerson, buildWcif } from '../../store/reducers/_tests_/helpers';
+import { countPeopleWithImmediateHelpingThenCompetingAssignments } from './bulkGenerationDiagnostics';
+import { describe, expect, it } from 'vitest';
+
+describe('bulkGenerationDiagnostics', () => {
+  it('counts people with immediate helping then competing assignments', () => {
+    const wcif = buildWcif(
+      [
+        buildActivity({
+          id: 1,
+          activityCode: '333-r1',
+          startTime: '2024-01-01T10:00:00Z',
+          endTime: '2024-01-01T11:00:00Z',
+          childActivities: [
+            buildActivity({
+              id: 101,
+              activityCode: '333-r1-g1',
+              startTime: '2024-01-01T10:00:00Z',
+              endTime: '2024-01-01T10:15:00Z',
+            }),
+            buildActivity({
+              id: 102,
+              activityCode: '333-r1-g2',
+              startTime: '2024-01-01T10:15:00Z',
+              endTime: '2024-01-01T10:30:00Z',
+            }),
+            buildActivity({
+              id: 103,
+              activityCode: '333-r1-g3',
+              startTime: '2024-01-01T10:45:00Z',
+              endTime: '2024-01-01T11:00:00Z',
+            }),
+          ],
+        }),
+      ],
+      [
+        buildPerson({
+          registrantId: 1,
+          assignments: [
+            { activityId: 101, assignmentCode: 'staff-judge', stationNumber: null },
+            { activityId: 102, assignmentCode: 'competitor', stationNumber: null },
+          ],
+        }),
+        buildPerson({
+          registrantId: 2,
+          assignments: [
+            { activityId: 101, assignmentCode: 'staff-runner', stationNumber: null },
+            { activityId: 103, assignmentCode: 'competitor', stationNumber: null },
+          ],
+        }),
+        buildPerson({
+          registrantId: 3,
+          assignments: [
+            { activityId: 101, assignmentCode: 'competitor', stationNumber: null },
+            { activityId: 102, assignmentCode: 'staff-judge', stationNumber: null },
+          ],
+        }),
+      ]
+    );
+
+    expect(countPeopleWithImmediateHelpingThenCompetingAssignments(wcif)).toBe(1);
+  });
+});

--- a/src/lib/recipes/bulkGenerationDiagnostics.ts
+++ b/src/lib/recipes/bulkGenerationDiagnostics.ts
@@ -1,4 +1,5 @@
 import { isCompetitorAssignment, isStaffAssignment } from '../domain/assignments';
+import { parseActivityCode } from '../domain/activities';
 import { findAllActivities } from '../wcif/activities';
 import type { Activity, Assignment, Competition } from '@wca/helpers';
 
@@ -30,6 +31,46 @@ const assignmentsBySchedule = (
         assignmentA.activity.id - assignmentB.activity.id
     );
 
+const roundKeyFor = (activity: Activity) => {
+  const { eventId, roundNumber } = parseActivityCode(activity.activityCode);
+  return roundNumber ? `${eventId}-r${roundNumber}` : null;
+};
+
+const groupNumberCountsByRound = (activities: Activity[]) => {
+  const groupNumbersByRound = activities.reduce((groups, activity) => {
+    const { groupNumber } = parseActivityCode(activity.activityCode);
+    const roundKey = roundKeyFor(activity);
+
+    if (roundKey && groupNumber) {
+      groups.set(roundKey, (groups.get(roundKey) ?? new Set<number>()).add(groupNumber));
+    }
+
+    return groups;
+  }, new Map<string, Set<number>>());
+
+  return new Map(
+    [...groupNumbersByRound.entries()].map(([roundKey, groupNumbers]) => [
+      roundKey,
+      groupNumbers.size,
+    ])
+  );
+};
+
+const isTwoGroupSameRoundHelpingThenCompeting = (
+  helpingAssignment: ScheduledAssignment,
+  competingAssignment: ScheduledAssignment,
+  roundGroupCounts: Map<string, number>
+) => {
+  const helpingRoundKey = roundKeyFor(helpingAssignment.activity);
+  const competingRoundKey = roundKeyFor(competingAssignment.activity);
+
+  return (
+    helpingRoundKey !== null &&
+    helpingRoundKey === competingRoundKey &&
+    roundGroupCounts.get(helpingRoundKey) === 2
+  );
+};
+
 const isImmediateHelpingThenCompeting = (
   helpingAssignment: ScheduledAssignment,
   competingAssignment: ScheduledAssignment
@@ -42,16 +83,23 @@ const isImmediateHelpingThenCompeting = (
     new Date(competingAssignment.activity.startTime).getTime();
 
 export const countPeopleWithImmediateHelpingThenCompetingAssignments = (wcif: Competition) => {
-  const activityById = new Map(findAllActivities(wcif).map((activity) => [activity.id, activity]));
+  const activities = findAllActivities(wcif);
+  const activityById = new Map(activities.map((activity) => [activity.id, activity]));
+  const roundGroupCounts = groupNumberCountsByRound(activities);
 
   return wcif.persons.filter((person) => {
     const assignments = assignmentsBySchedule(person.assignments, activityById);
 
     return assignments.some((assignment, index) => {
       const nextAssignment = assignments[index + 1];
-      return nextAssignment
-        ? isImmediateHelpingThenCompeting(assignment, nextAssignment)
-        : false;
+      if (!nextAssignment) {
+        return false;
+      }
+
+      return (
+        isImmediateHelpingThenCompeting(assignment, nextAssignment) &&
+        !isTwoGroupSameRoundHelpingThenCompeting(assignment, nextAssignment, roundGroupCounts)
+      );
     });
   }).length;
 };

--- a/src/lib/recipes/bulkGenerationDiagnostics.ts
+++ b/src/lib/recipes/bulkGenerationDiagnostics.ts
@@ -1,0 +1,57 @@
+import { isCompetitorAssignment, isStaffAssignment } from '../domain/assignments';
+import { findAllActivities } from '../wcif/activities';
+import type { Activity, Assignment, Competition } from '@wca/helpers';
+
+interface ScheduledAssignment {
+  assignment: Assignment;
+  activity: Activity;
+}
+
+const activityStartTime = (activity: Activity) =>
+  activity.startTime ? new Date(activity.startTime).getTime() : Number.POSITIVE_INFINITY;
+
+const activityEndTime = (activity: Activity) =>
+  activity.endTime ? new Date(activity.endTime).getTime() : Number.POSITIVE_INFINITY;
+
+const assignmentsBySchedule = (
+  assignments: Assignment[] | undefined,
+  activityById: Map<number, Activity>
+): ScheduledAssignment[] =>
+  (assignments ?? [])
+    .map((assignment) => {
+      const activity = activityById.get(assignment.activityId);
+      return activity ? { assignment, activity } : null;
+    })
+    .filter((assignment): assignment is ScheduledAssignment => Boolean(assignment))
+    .sort(
+      (assignmentA, assignmentB) =>
+        activityStartTime(assignmentA.activity) - activityStartTime(assignmentB.activity) ||
+        activityEndTime(assignmentA.activity) - activityEndTime(assignmentB.activity) ||
+        assignmentA.activity.id - assignmentB.activity.id
+    );
+
+const isImmediateHelpingThenCompeting = (
+  helpingAssignment: ScheduledAssignment,
+  competingAssignment: ScheduledAssignment
+) =>
+  isStaffAssignment(helpingAssignment.assignment) &&
+  isCompetitorAssignment(competingAssignment.assignment) &&
+  helpingAssignment.activity.endTime &&
+  competingAssignment.activity.startTime &&
+  new Date(helpingAssignment.activity.endTime).getTime() ===
+    new Date(competingAssignment.activity.startTime).getTime();
+
+export const countPeopleWithImmediateHelpingThenCompetingAssignments = (wcif: Competition) => {
+  const activityById = new Map(findAllActivities(wcif).map((activity) => [activity.id, activity]));
+
+  return wcif.persons.filter((person) => {
+    const assignments = assignmentsBySchedule(person.assignments, activityById);
+
+    return assignments.some((assignment, index) => {
+      const nextAssignment = assignments[index + 1];
+      return nextAssignment
+        ? isImmediateHelpingThenCompeting(assignment, nextAssignment)
+        : false;
+    });
+  }).length;
+};

--- a/src/lib/recipes/clusters.test.ts
+++ b/src/lib/recipes/clusters.test.ts
@@ -1,0 +1,48 @@
+import { sortCluster } from './clusters';
+import {
+  buildActivity,
+  buildEvent,
+  buildPerson,
+  buildWcifWithEvents,
+} from '../../store/reducers/_tests_/helpers';
+import { describe, expect, it } from 'vitest';
+
+const group = (id: number, groupNumber: number) =>
+  buildActivity({
+    id,
+    name: `Group ${groupNumber}`,
+    activityCode: `333-r1-g${groupNumber}`,
+  });
+
+describe('recipe clusters', () => {
+  it('sorts most constrained people before less constrained people', () => {
+    const activities = [group(11, 1), group(12, 2)];
+    const persons = [
+      buildPerson({ registrantId: 1, name: 'Regular Person' }),
+      buildPerson({ registrantId: 2, name: 'First Timer', wcaId: null }),
+      buildPerson({ registrantId: 3, name: 'Delegate Person', roles: ['delegate'] }),
+      buildPerson({
+        registrantId: 4,
+        name: 'Staff Person',
+        assignments: [{ activityId: 11, assignmentCode: 'staff-judge', stationNumber: null }],
+      }),
+      buildPerson({ registrantId: 5, name: 'Luke Alpha' }),
+      buildPerson({ registrantId: 6, name: 'Luke Beta' }),
+    ];
+    const wcif = buildWcifWithEvents([], [buildEvent()], persons);
+
+    const sorted = sortCluster(
+      wcif,
+      {
+        base: 'personsInRound',
+        filters: [],
+        sort: { by: 'mostConstrained', direction: 'desc' },
+      },
+      persons,
+      '333-r1',
+      activities
+    );
+
+    expect(sorted.map((person) => person.registrantId)).toEqual([4, 3, 2, 5, 6, 1]);
+  });
+});

--- a/src/lib/recipes/clusters.ts
+++ b/src/lib/recipes/clusters.ts
@@ -1,8 +1,9 @@
-import { Competition, Event, Person, Round, parseActivityCode } from '@wca/helpers';
+import { parseActivityCode } from '@wca/helpers';
+import type { Activity, Competition, Event, Person, Round } from '@wca/helpers';
 import Assignments from '../../config/assignments';
 import { findGroupActivitiesByRound } from '../wcif/activities';
 import { acceptedRegistrations, personsShouldBeInRound } from '../domain/persons';
-import { ClusterDefinition } from './types';
+import type { ClusterDefinition } from './types';
 import { byPROrResult } from 'wca-group-generators';
 
 export const Filters = [
@@ -103,7 +104,66 @@ export const getBaseCluster = (
   }
 };
 
-export const sortCluster = (wcif: Competition, cluster: ClusterDefinition, persons: Person[], roundId: string) => {
+const KEY_STAFF_ROLES = ['delegate', 'trainee-delegate', 'organizer'];
+
+const firstNameFor = (name: string) => name.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+
+const phoneticFirstNameFor = (name: string) =>
+  firstNameFor(name)
+    .replace(/[^a-z]/g, '')
+    .replace(/ph/g, 'f')
+    .replace(/^c/, 'k')
+    .replace(/^q/, 'k')
+    .replace(/[sz]/g, 's')
+    .replace(/h/g, '')
+    .replace(/(.)\1+/g, '$1');
+
+const staffAssignmentCount = (person: Person, activityIds: number[]) =>
+  person.assignments?.filter(
+    (assignment) =>
+      activityIds.includes(assignment.activityId) && assignment.assignmentCode.startsWith('staff-')
+  ).length ?? 0;
+
+const assignmentCount = (person: Person, activityIds: number[]) =>
+  person.assignments?.filter((assignment) => activityIds.includes(assignment.activityId)).length ??
+  0;
+
+const keyRoleCount = (person: Person) =>
+  KEY_STAFF_ROLES.filter((role) => person.roles?.includes(role)).length;
+
+const similarFirstNameCount = (person: Person, persons: Person[]) => {
+  const firstName = firstNameFor(person.name);
+  const phoneticFirstName = phoneticFirstNameFor(person.name);
+
+  return persons.filter((candidate) => {
+    if (candidate.registrantId === person.registrantId) {
+      return false;
+    }
+
+    const candidateFirstName = firstNameFor(candidate.name);
+    return (
+      candidateFirstName === firstName ||
+      candidateFirstName.startsWith(firstName) ||
+      firstName.startsWith(candidateFirstName) ||
+      phoneticFirstNameFor(candidate.name) === phoneticFirstName
+    );
+  }).length;
+};
+
+const constrainedScore = (person: Person, persons: Person[], activityIds: number[]) =>
+  staffAssignmentCount(person, activityIds) * 1000 +
+  keyRoleCount(person) * 800 +
+  (!person.wcaId ? 400 : 0) +
+  similarFirstNameCount(person, persons) * 100 +
+  assignmentCount(person, activityIds) * 25;
+
+export const sortCluster = (
+  wcif: Competition,
+  cluster: ClusterDefinition,
+  persons: Person[],
+  roundId: string,
+  activities: Activity[]
+) => {
   if (!cluster.sort) {
     return persons;
   }
@@ -118,12 +178,34 @@ export const sortCluster = (wcif: Competition, cluster: ClusterDefinition, perso
     return cluster.sort.direction === 'asc' ? sortedPersons : sortedPersons.reverse();
   }
 
+  if (cluster.sort.by === 'mostConstrained') {
+    const activityIds = activities.map((activity) => activity.id);
+    const { eventId, roundNumber } = parseActivityCode(roundId) as {
+      eventId: string;
+      roundNumber: number;
+    };
+    const event = wcif.events.find((e) => e.id === eventId) as Event;
+    const speedComparator = byPROrResult(event, roundNumber);
+    const sortedPersons = [...persons].sort((personA, personB) => {
+      const scoreDiff =
+        constrainedScore(personB, persons, activityIds) -
+        constrainedScore(personA, persons, activityIds);
+
+      return (
+        scoreDiff || speedComparator(personA, personB) || personA.name.localeCompare(personB.name)
+      );
+    });
+
+    return cluster.sort.direction === 'desc' ? sortedPersons : sortedPersons.reverse();
+  }
+
   return persons;
-}
+};
 
 
 export const getCluster = (wcif: Competition, cluster: ClusterDefinition, roundId: string) => {
-  const activityIds = findGroupActivitiesByRound(wcif, roundId).map((a) => a.id);
+  const activities = findGroupActivitiesByRound(wcif, roundId);
+  const activityIds = activities.map((a) => a.id);
 
   const baseCluster = getBaseCluster(wcif, cluster.base, roundId);
 
@@ -141,5 +223,5 @@ export const getCluster = (wcif: Competition, cluster: ClusterDefinition, roundI
     return acc.filter(filter(value, activityIds));
   }, baseCluster);
 
-  return sortCluster(wcif, cluster, filteredCluster, roundId);
+  return sortCluster(wcif, cluster, filteredCluster, roundId, activities);
 };

--- a/src/lib/recipes/conditions.ts
+++ b/src/lib/recipes/conditions.ts
@@ -1,0 +1,28 @@
+import type { Activity, Competition } from '@wca/helpers';
+import type { GroupStep } from './types';
+
+const isFinalRound = (wcif: Competition, roundId: string) => {
+  const event = wcif.events.find((candidateEvent) =>
+    candidateEvent.rounds.some((round) => round.id === roundId)
+  );
+  if (!event) return false;
+
+  return event.rounds[event.rounds.length - 1]?.id === roundId;
+};
+
+const hasGroupActivities = (roundActivities: Activity[]) =>
+  roundActivities.some((roundActivity) => (roundActivity.childActivities ?? []).length > 0);
+
+export const shouldRunGroupStep = (
+  wcif: Competition,
+  roundId: string,
+  roundActivities: Activity[],
+  step: GroupStep
+) => {
+  switch (step.props.condition) {
+    case 'missingGroupsInFinalRound':
+      return isFinalRound(wcif, roundId) && !hasGroupActivities(roundActivities);
+    default:
+      return true;
+  }
+};

--- a/src/lib/recipes/constraints.test.ts
+++ b/src/lib/recipes/constraints.test.ts
@@ -1,4 +1,5 @@
 import {
+  avoidImmediateHelpingThenCompeting,
   avoidSimilarFirstNames,
   maximizeAssignmentGaps,
   mustNotHaveRoles,
@@ -244,5 +245,55 @@ describe('recipe constraints', () => {
     };
 
     expect(maximizeAssignmentGaps.score(props)).toBe(-100);
+  });
+
+  it('rejects staff assignments immediately before a future competitor assignment', () => {
+    const immediateStaffActivity = buildTimedActivity(
+      51,
+      '333-r1-g1',
+      '2024-01-01T10:00:00.000Z',
+      '2024-01-01T10:10:00.000Z'
+    );
+    const futureCompetitorActivity = buildTimedActivity(
+      61,
+      '222-r1-g1',
+      '2024-01-01T10:10:00.000Z',
+      '2024-01-01T10:20:00.000Z'
+    );
+    const props = {
+      ...scoreProps(immediateStaffActivity, [immediateStaffActivity]),
+      assignmentCode: 'staff-judge',
+      wcif: buildWcif([immediateStaffActivity, futureCompetitorActivity]),
+      person: buildPerson({
+        assignments: [{ activityId: 61, assignmentCode: 'competitor', stationNumber: null }],
+      }),
+    };
+
+    expect(avoidImmediateHelpingThenCompeting.score(props)).toBeNull();
+  });
+
+  it('allows immediate help then compete assignments within two-group rounds', () => {
+    const firstGroup = buildTimedActivity(
+      51,
+      '333-r1-g1',
+      '2024-01-01T10:00:00.000Z',
+      '2024-01-01T10:10:00.000Z'
+    );
+    const secondGroup = buildTimedActivity(
+      52,
+      '333-r1-g2',
+      '2024-01-01T10:10:00.000Z',
+      '2024-01-01T10:20:00.000Z'
+    );
+    const props = {
+      ...scoreProps(firstGroup, [firstGroup, secondGroup]),
+      assignmentCode: 'staff-judge',
+      wcif: buildWcif([firstGroup, secondGroup]),
+      person: buildPerson({
+        assignments: [{ activityId: 52, assignmentCode: 'competitor', stationNumber: null }],
+      }),
+    };
+
+    expect(avoidImmediateHelpingThenCompeting.score(props)).toBe(0);
   });
 });

--- a/src/lib/recipes/constraints.test.ts
+++ b/src/lib/recipes/constraints.test.ts
@@ -1,5 +1,6 @@
 import {
   avoidSimilarFirstNames,
+  maximizeAssignmentGaps,
   mustNotHaveRoles,
   onlyMultipleGroupRounds,
   preferLaterGroups,
@@ -14,8 +15,22 @@ const buildGroup = (id: number, groupNumber: number): Activity =>
     id,
     name: `Group ${groupNumber}`,
     activityCode: `333-r1-g${groupNumber}`,
-    startTime: `2024-01-01T10:0${groupNumber}:00Z`,
-    endTime: `2024-01-01T10:1${groupNumber}:00Z`,
+    startTime: new Date(Date.UTC(2024, 0, 1, 10, (groupNumber - 1) * 10)).toISOString(),
+    endTime: new Date(Date.UTC(2024, 0, 1, 10, groupNumber * 10)).toISOString(),
+  });
+
+const buildTimedActivity = (
+  id: number,
+  activityCode: string,
+  startTime: string,
+  endTime: string
+): Activity =>
+  buildActivity({
+    id,
+    name: activityCode,
+    activityCode,
+    startTime,
+    endTime,
   });
 
 const scoreProps = (activity: Activity, activities: Activity[]) => ({
@@ -112,5 +127,122 @@ describe('recipe constraints', () => {
 
     expect(avoidSimilarFirstNames.score(props)).toBeNull();
     expect(avoidSimilarFirstNames.score({ ...props, activity: activities[1] })).toBe(0);
+  });
+
+  it('penalizes but does not reject competitor assignments immediately after helping', () => {
+    const staffActivity = buildTimedActivity(
+      21,
+      '333-r1-g1',
+      '2024-01-01T10:00:00.000Z',
+      '2024-01-01T10:10:00.000Z'
+    );
+    const immediateCompetitorActivity = buildTimedActivity(
+      22,
+      '333-r1-g2',
+      '2024-01-01T10:10:00.000Z',
+      '2024-01-01T10:20:00.000Z'
+    );
+    const props = {
+      ...scoreProps(immediateCompetitorActivity, [immediateCompetitorActivity]),
+      wcif: buildWcif([staffActivity, immediateCompetitorActivity]),
+      person: buildPerson({
+        assignments: [{ activityId: 21, assignmentCode: 'staff-judge', stationNumber: null }],
+      }),
+      options: { noGapPenalty: 100, gapCapMinutes: 120 },
+    };
+
+    expect(maximizeAssignmentGaps.score(props)).toBe(-100);
+  });
+
+  it('scores larger positive staff-to-competitor gaps higher', () => {
+    const staffActivity = buildTimedActivity(
+      21,
+      '333-r1-g1',
+      '2024-01-01T10:00:00.000Z',
+      '2024-01-01T10:10:00.000Z'
+    );
+    const shortGapActivity = buildTimedActivity(
+      22,
+      '333-r1-g2',
+      '2024-01-01T10:15:00.000Z',
+      '2024-01-01T10:25:00.000Z'
+    );
+    const longGapActivity = buildTimedActivity(
+      23,
+      '333-r1-g3',
+      '2024-01-01T10:50:00.000Z',
+      '2024-01-01T11:00:00.000Z'
+    );
+    const props = {
+      ...scoreProps(shortGapActivity, [shortGapActivity, longGapActivity]),
+      wcif: buildWcif([staffActivity, shortGapActivity, longGapActivity]),
+      person: buildPerson({
+        assignments: [{ activityId: 21, assignmentCode: 'staff-runner', stationNumber: null }],
+      }),
+      options: { noGapPenalty: 100, gapCapMinutes: 120 },
+    };
+
+    expect(maximizeAssignmentGaps.score({ ...props, activity: longGapActivity })).toBeGreaterThan(
+      maximizeAssignmentGaps.score(props) ?? 0
+    );
+  });
+
+  it('scores competitor assignments farther from other rounds higher', () => {
+    const otherRoundActivity = buildTimedActivity(
+      31,
+      '222-r1-g1',
+      '2024-01-01T10:00:00.000Z',
+      '2024-01-01T10:10:00.000Z'
+    );
+    const nearActivity = buildTimedActivity(
+      41,
+      '333-r1-g1',
+      '2024-01-01T10:15:00.000Z',
+      '2024-01-01T10:25:00.000Z'
+    );
+    const farActivity = buildTimedActivity(
+      42,
+      '333-r1-g2',
+      '2024-01-01T11:00:00.000Z',
+      '2024-01-01T11:10:00.000Z'
+    );
+    const props = {
+      ...scoreProps(nearActivity, [nearActivity, farActivity]),
+      wcif: buildWcif([otherRoundActivity, nearActivity, farActivity]),
+      person: buildPerson({
+        assignments: [{ activityId: 31, assignmentCode: 'competitor', stationNumber: null }],
+      }),
+      options: { noGapPenalty: 100, gapCapMinutes: 120 },
+    };
+
+    expect(maximizeAssignmentGaps.score({ ...props, activity: farActivity })).toBeGreaterThan(
+      maximizeAssignmentGaps.score(props) ?? 0
+    );
+  });
+
+  it('penalizes staff assignments immediately before future competitor assignments', () => {
+    const immediateStaffActivity = buildTimedActivity(
+      51,
+      '333-r1-g1',
+      '2024-01-01T10:00:00.000Z',
+      '2024-01-01T10:10:00.000Z'
+    );
+    const futureCompetitorActivity = buildTimedActivity(
+      61,
+      '222-r1-g1',
+      '2024-01-01T10:10:00.000Z',
+      '2024-01-01T10:20:00.000Z'
+    );
+    const props = {
+      ...scoreProps(immediateStaffActivity, [immediateStaffActivity]),
+      assignmentCode: 'staff-judge',
+      wcif: buildWcif([immediateStaffActivity, futureCompetitorActivity]),
+      person: buildPerson({
+        assignments: [{ activityId: 61, assignmentCode: 'competitor', stationNumber: null }],
+      }),
+      options: { noGapPenalty: 100, gapCapMinutes: 120 },
+    };
+
+    expect(maximizeAssignmentGaps.score(props)).toBe(-100);
   });
 });

--- a/src/lib/recipes/constraints.test.ts
+++ b/src/lib/recipes/constraints.test.ts
@@ -1,0 +1,99 @@
+import {
+  avoidSimilarFirstNames,
+  mustNotHaveRoles,
+  onlyMultipleGroupRounds,
+  preferLaterGroups,
+  shouldHelpAfterCompeting,
+} from './constraints';
+import { buildActivity, buildPerson, buildWcif } from '../../store/reducers/_tests_/helpers';
+import type { Activity } from '@wca/helpers';
+import { describe, expect, it } from 'vitest';
+
+const buildGroup = (id: number, groupNumber: number): Activity =>
+  buildActivity({
+    id,
+    name: `Group ${groupNumber}`,
+    activityCode: `333-r1-g${groupNumber}`,
+    startTime: `2024-01-01T10:0${groupNumber}:00Z`,
+    endTime: `2024-01-01T10:1${groupNumber}:00Z`,
+  });
+
+const scoreProps = (activity: Activity, activities: Activity[]) => ({
+  wcif: buildWcif([
+    buildActivity({
+      id: 1,
+      activityCode: '333-r1',
+      childActivities: activities,
+    }),
+  ]),
+  activities,
+  cluster: [],
+  assignmentCode: 'competitor',
+  person: buildPerson({
+    assignments: [{ activityId: 12, assignmentCode: 'staff-judge', stationNumber: null }],
+  }),
+  activity,
+});
+
+describe('recipe constraints', () => {
+  it('prefers the group before a staff assignment so staff help after competing', () => {
+    const activities = [buildGroup(11, 1), buildGroup(12, 2), buildGroup(13, 3)];
+
+    expect(shouldHelpAfterCompeting.score(scoreProps(activities[0], activities))).toBe(1);
+    expect(shouldHelpAfterCompeting.score(scoreProps(activities[2], activities))).toBe(0);
+  });
+
+  it('wraps staff competitor assignments from group one staff to the last competing group', () => {
+    const activities = [buildGroup(11, 1), buildGroup(12, 2), buildGroup(13, 3)];
+    const props = {
+      ...scoreProps(activities[2], activities),
+      person: buildPerson({
+        assignments: [{ activityId: 11, assignmentCode: 'staff-judge', stationNumber: null }],
+      }),
+    };
+
+    expect(shouldHelpAfterCompeting.score(props)).toBe(1);
+  });
+
+  it('scores later groups higher', () => {
+    const activities = [buildGroup(11, 1), buildGroup(12, 2), buildGroup(13, 3)];
+
+    const earlyScore = preferLaterGroups.score(scoreProps(activities[0], activities));
+    const lateScore = preferLaterGroups.score(scoreProps(activities[2], activities));
+
+    expect(lateScore).toBeGreaterThan(earlyScore ?? 0);
+  });
+
+  it('rejects people with blocked roles', () => {
+    const activity = buildGroup(11, 1);
+    const props = {
+      ...scoreProps(activity, [activity]),
+      person: buildPerson({ roles: ['organizer'] }),
+      options: { roles: ['delegate', 'trainee-delegate', 'organizer'] },
+    };
+
+    expect(mustNotHaveRoles.score(props)).toBeNull();
+  });
+
+  it('rejects judge assignments when only one group exists', () => {
+    const activity = buildGroup(11, 1);
+
+    expect(onlyMultipleGroupRounds.score(scoreProps(activity, [activity]))).toBeNull();
+  });
+
+  it('penalizes same-sounding first names in the same activity', () => {
+    const activity = buildGroup(11, 1);
+    const props = {
+      ...scoreProps(activity, [activity]),
+      wcif: buildWcif([], [
+        buildPerson({
+          name: 'John Smith',
+          assignments: [{ activityId: 11, assignmentCode: 'competitor', stationNumber: null }],
+        }),
+      ]),
+      person: buildPerson({ name: 'Jon Jones' }),
+    };
+
+    expect(avoidSimilarFirstNames.score(props)).toBeLessThan(0);
+  });
+});

--- a/src/lib/recipes/constraints.test.ts
+++ b/src/lib/recipes/constraints.test.ts
@@ -96,4 +96,21 @@ describe('recipe constraints', () => {
 
     expect(avoidSimilarFirstNames.score(props)).toBeLessThan(0);
   });
+
+  it('rejects same-sounding first names when another activity is available', () => {
+    const activities = [buildGroup(11, 1), buildGroup(12, 2)];
+    const props = {
+      ...scoreProps(activities[0], activities),
+      wcif: buildWcif([], [
+        buildPerson({
+          name: 'Ethan Smith',
+          assignments: [{ activityId: 11, assignmentCode: 'competitor', stationNumber: null }],
+        }),
+      ]),
+      person: buildPerson({ name: 'Ethan Jones' }),
+    };
+
+    expect(avoidSimilarFirstNames.score(props)).toBeNull();
+    expect(avoidSimilarFirstNames.score({ ...props, activity: activities[1] })).toBe(0);
+  });
 });

--- a/src/lib/recipes/constraints.ts
+++ b/src/lib/recipes/constraints.ts
@@ -114,28 +114,40 @@ export const onlyMultipleGroupRounds: Constraint = {
 
 export const avoidSimilarFirstNames: Constraint = {
   name: 'Avoid Similar First Names',
-  score: ({ wcif, activity, assignmentCode, person }) => {
+  score: ({ wcif, activities, activity, assignmentCode, person }) => {
     const firstName = firstNameFor(person.name);
     const phoneticFirstName = phoneticFirstNameFor(person.name);
 
-    const peopleInActivity = wcif.persons.filter((candidate) =>
-      candidate.assignments?.some(
-        (assignment) =>
-          assignment.assignmentCode === assignmentCode && assignment.activityId === activity.id
-      )
+    const conflictCountForActivity = (candidateActivity: Activity) => {
+      const peopleInActivity = wcif.persons.filter((candidate) =>
+        candidate.assignments?.some(
+          (assignment) =>
+            assignment.assignmentCode === assignmentCode &&
+            assignment.activityId === candidateActivity.id
+        )
+      );
+
+      return peopleInActivity.filter((candidate) => {
+        const candidateFirstName = firstNameFor(candidate.name);
+        return (
+          candidateFirstName === firstName ||
+          candidateFirstName.startsWith(firstName) ||
+          firstName.startsWith(candidateFirstName) ||
+          phoneticFirstNameFor(candidate.name) === phoneticFirstName
+        );
+      }).length;
+    };
+
+    const conflicts = conflictCountForActivity(activity);
+    if (conflicts === 0) {
+      return 0;
+    }
+
+    const hasConflictFreeActivity = activities.some(
+      (candidateActivity) => conflictCountForActivity(candidateActivity) === 0
     );
 
-    const conflicts = peopleInActivity.filter((candidate) => {
-      const candidateFirstName = firstNameFor(candidate.name);
-      return (
-        candidateFirstName === firstName ||
-        candidateFirstName.startsWith(firstName) ||
-        firstName.startsWith(candidateFirstName) ||
-        phoneticFirstNameFor(candidate.name) === phoneticFirstName
-      );
-    });
-
-    return -conflicts.length;
+    return hasConflictFreeActivity ? null : -conflicts;
   },
 };
 

--- a/src/lib/recipes/constraints.ts
+++ b/src/lib/recipes/constraints.ts
@@ -1,7 +1,8 @@
-import { parseActivityCode } from '@wca/helpers';
+import { parseActivityCode } from '../domain/activities';
 import { roomByActivity, type Constraint } from 'wca-group-generators';
 
 type Activity = Parameters<Constraint['score']>[0]['activity'];
+type Wcif = Parameters<Constraint['score']>[0]['wcif'];
 
 const DEFAULT_KEY_STAFF_ROLES = ['delegate', 'trainee-delegate', 'organizer'];
 const DEFAULT_GAP_CAP_MINUTES = 120;
@@ -68,21 +69,65 @@ const activitiesOverlap = (first: Activity, second: Activity) =>
   new Date(first.startTime) < new Date(second.endTime) &&
   new Date(second.startTime) < new Date(first.endTime);
 
-const assignmentActivitiesForPerson = (
-  wcif: Parameters<Constraint['score']>[0]['wcif'],
-  person: Parameters<Constraint['score']>[0]['person'],
-  assignmentTest: (assignmentCode: string) => boolean
-) => {
-  const allActivities = wcif.schedule.venues.flatMap((venue) =>
+const groupNumberCountsByRound = (activities: Activity[]) => {
+  const groupNumbersByRound = activities.reduce((groups, activity) => {
+    const groupNumber = groupNumberFor(activity);
+    const roundKey = roundKeyFor(activity);
+
+    if (groupNumber) {
+      groups.set(roundKey, (groups.get(roundKey) ?? new Set<number>()).add(groupNumber));
+    }
+
+    return groups;
+  }, new Map<string, Set<number>>());
+
+  return new Map(
+    [...groupNumbersByRound.entries()].map(([roundKey, groupNumbers]) => [
+      roundKey,
+      groupNumbers.size,
+    ])
+  );
+};
+
+const scheduleContextCache = new WeakMap<
+  Wcif['schedule'],
+  {
+    activityById: Map<number, Activity>;
+    groupNumberCountsByRound: Map<string, number>;
+  }
+>();
+
+const scheduleContextFor = (wcif: Wcif) => {
+  const cached = scheduleContextCache.get(wcif.schedule);
+  if (cached) {
+    return cached;
+  }
+
+  const activities = wcif.schedule.venues.flatMap((venue) =>
     venue.rooms.flatMap((room) =>
       room.activities.flatMap((activity) => [activity, ...(activity.childActivities ?? [])])
     )
   );
+  const context = {
+    activityById: new Map(activities.map((activity) => [activity.id, activity])),
+    groupNumberCountsByRound: groupNumberCountsByRound(activities),
+  };
+
+  scheduleContextCache.set(wcif.schedule, context);
+  return context;
+};
+
+const assignmentActivitiesForPerson = (
+  wcif: Wcif,
+  person: Parameters<Constraint['score']>[0]['person'],
+  assignmentTest: (assignmentCode: string) => boolean
+) => {
+  const { activityById } = scheduleContextFor(wcif);
 
   return (
     person.assignments
       ?.filter((assignment) => assignmentTest(assignment.assignmentCode))
-      .map((assignment) => allActivities.find((activity) => activity.id === assignment.activityId))
+      .map((assignment) => activityById.get(assignment.activityId))
       .filter(Boolean) as Activity[]
   ).sort((a, b) => a.startTime.localeCompare(b.startTime));
 };
@@ -154,6 +199,19 @@ const staffBeforeFutureCompetitorGapScore = (
     )
   );
 };
+
+const isTwoGroupSameRoundTransition = (
+  firstActivity: Activity,
+  secondActivity: Activity,
+  roundGroupCounts: Map<string, number>
+) =>
+  roundKeyFor(firstActivity) === roundKeyFor(secondActivity) &&
+  roundGroupCounts.get(roundKeyFor(firstActivity)) === 2;
+
+const isImmediateTransition = (firstActivity: Activity, secondActivity: Activity) =>
+  firstActivity.endTime &&
+  secondActivity.startTime &&
+  new Date(firstActivity.endTime).getTime() === new Date(secondActivity.startTime).getTime();
 
 export const shouldHelpAfterCompeting: Constraint = {
   name: 'Should Help After Competing',
@@ -292,6 +350,48 @@ export const maximizeAssignmentGaps: Constraint = {
   },
 };
 
+export const avoidImmediateHelpingThenCompeting: Constraint = {
+  name: 'Avoid Immediate Helping Then Competing',
+  score: ({ wcif, activity, assignmentCode, person }) => {
+    const scoredPerson = wcif.persons.find(
+      (candidate) => candidate.registrantId === person.registrantId
+    ) ?? person;
+    const { groupNumberCountsByRound: roundGroupCounts } = scheduleContextFor(wcif);
+    const staffActivities = assignmentActivitiesForPerson(
+      wcif,
+      scoredPerson,
+      isStaffAssignmentCode
+    );
+    const competitorActivities = assignmentActivitiesForPerson(
+      wcif,
+      scoredPerson,
+      isCompetitorAssignmentCode
+    );
+
+    if (isCompetitorAssignmentCode(assignmentCode)) {
+      const hasImmediatePriorStaffActivity = staffActivities.some(
+        (staffActivity) =>
+          isImmediateTransition(staffActivity, activity) &&
+          !isTwoGroupSameRoundTransition(staffActivity, activity, roundGroupCounts)
+      );
+
+      return hasImmediatePriorStaffActivity ? null : 0;
+    }
+
+    if (isStaffAssignmentCode(assignmentCode)) {
+      const hasImmediateFutureCompetitorActivity = competitorActivities.some(
+        (competitorActivity) =>
+          isImmediateTransition(activity, competitorActivity) &&
+          !isTwoGroupSameRoundTransition(activity, competitorActivity, roundGroupCounts)
+      );
+
+      return hasImmediateFutureCompetitorActivity ? null : 0;
+    }
+
+    return 0;
+  },
+};
+
 export const RecipeConstraints: Record<string, Constraint> = {
   shouldHelpAfterCompeting,
   preferLaterGroups,
@@ -299,4 +399,5 @@ export const RecipeConstraints: Record<string, Constraint> = {
   onlyMultipleGroupRounds,
   avoidSimilarFirstNames,
   maximizeAssignmentGaps,
+  avoidImmediateHelpingThenCompeting,
 };

--- a/src/lib/recipes/constraints.ts
+++ b/src/lib/recipes/constraints.ts
@@ -1,0 +1,148 @@
+import { parseActivityCode, type Activity } from '@wca/helpers';
+import { roomByActivity, type Constraint } from 'wca-group-generators';
+
+const DEFAULT_KEY_STAFF_ROLES = ['delegate', 'trainee-delegate', 'organizer'];
+
+const isStaffAssignmentCode = (assignmentCode: string) => assignmentCode.startsWith('staff-');
+
+const firstNameFor = (name: string) => name.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+
+const phoneticFirstNameFor = (name: string) => {
+  return firstNameFor(name)
+    .replace(/[^a-z]/g, '')
+    .replace(/ph/g, 'f')
+    .replace(/^c/, 'k')
+    .replace(/^q/, 'k')
+    .replace(/[sz]/g, 's')
+    .replace(/h/g, '')
+    .replace(/(.)\1+/g, '$1');
+};
+
+const groupNumberFor = (activity: Activity) => parseActivityCode(activity.activityCode).groupNumber;
+
+const roundKeyFor = (activity: Activity) => {
+  const { eventId, roundNumber } = parseActivityCode(activity.activityCode);
+  return `${eventId}-r${roundNumber}`;
+};
+
+const sameRoomActivities = (
+  wcif: Parameters<Constraint['score']>[0]['wcif'],
+  activities: Activity[],
+  activity: Activity
+) => {
+  const activityRoom = roomByActivity(wcif, activity.id);
+
+  return activities.filter((candidate) => {
+    const candidateRoom = roomByActivity(wcif, candidate.id);
+    return (
+      candidateRoom?.id === activityRoom?.id && roundKeyFor(candidate) === roundKeyFor(activity)
+    );
+  });
+};
+
+const earliestStaffActivityForPerson = (
+  activities: Activity[],
+  person: Parameters<Constraint['score']>[0]['person']
+) => {
+  const staffActivities =
+    person.assignments
+      ?.filter((assignment) => isStaffAssignmentCode(assignment.assignmentCode))
+      .map((assignment) => activities.find((activity) => activity.id === assignment.activityId))
+      .filter(Boolean) ?? [];
+
+  return (staffActivities as Activity[]).sort((a, b) => a.startTime.localeCompare(b.startTime))[0];
+};
+
+export const shouldHelpAfterCompeting: Constraint = {
+  name: 'Should Help After Competing',
+  score: ({ wcif, activities, activity, person }) => {
+    const staffActivity = earliestStaffActivityForPerson(activities, person);
+    if (!staffActivity) {
+      return 0;
+    }
+
+    const staffGroupNumber = groupNumberFor(staffActivity);
+    if (!staffGroupNumber) {
+      return 0;
+    }
+
+    const stageActivities = sameRoomActivities(wcif, activities, staffActivity);
+    const groupNumbers = stageActivities.map(groupNumberFor).filter(Boolean) as number[];
+    if (!groupNumbers.length) {
+      return 0;
+    }
+
+    const previousGroupNumber =
+      ((staffGroupNumber - 2 + groupNumbers.length) % groupNumbers.length) + 1;
+
+    return groupNumberFor(activity) === previousGroupNumber ? 1 : 0;
+  },
+};
+
+export const preferLaterGroups: Constraint = {
+  name: 'Prefer Later Groups',
+  score: ({ activities, activity }) => {
+    const groupNumber = groupNumberFor(activity);
+    const maxGroupNumber = Math.max(...activities.map(groupNumberFor).filter(Boolean) as number[]);
+
+    if (!groupNumber || !Number.isFinite(maxGroupNumber) || maxGroupNumber <= 0) {
+      return 0;
+    }
+
+    return groupNumber / maxGroupNumber;
+  },
+};
+
+export const mustNotHaveRoles: Constraint = {
+  name: 'Must Not Have Roles',
+  score: ({ person, options }) => {
+    const roles = (options?.roles ?? DEFAULT_KEY_STAFF_ROLES) as string[];
+    const hasRole = roles.some((role) => person.roles?.includes(role));
+
+    return hasRole ? null : 0;
+  },
+};
+
+export const onlyMultipleGroupRounds: Constraint = {
+  name: 'Only Multiple Group Rounds',
+  score: ({ activities }) => {
+    const groupNumbers = new Set(activities.map(groupNumberFor).filter(Boolean));
+
+    return groupNumbers.size <= 1 ? null : 0;
+  },
+};
+
+export const avoidSimilarFirstNames: Constraint = {
+  name: 'Avoid Similar First Names',
+  score: ({ wcif, activity, assignmentCode, person }) => {
+    const firstName = firstNameFor(person.name);
+    const phoneticFirstName = phoneticFirstNameFor(person.name);
+
+    const peopleInActivity = wcif.persons.filter((candidate) =>
+      candidate.assignments?.some(
+        (assignment) =>
+          assignment.assignmentCode === assignmentCode && assignment.activityId === activity.id
+      )
+    );
+
+    const conflicts = peopleInActivity.filter((candidate) => {
+      const candidateFirstName = firstNameFor(candidate.name);
+      return (
+        candidateFirstName === firstName ||
+        candidateFirstName.startsWith(firstName) ||
+        firstName.startsWith(candidateFirstName) ||
+        phoneticFirstNameFor(candidate.name) === phoneticFirstName
+      );
+    });
+
+    return -conflicts.length;
+  },
+};
+
+export const RecipeConstraints: Record<string, Constraint> = {
+  shouldHelpAfterCompeting,
+  preferLaterGroups,
+  mustNotHaveRoles,
+  onlyMultipleGroupRounds,
+  avoidSimilarFirstNames,
+};

--- a/src/lib/recipes/constraints.ts
+++ b/src/lib/recipes/constraints.ts
@@ -1,9 +1,14 @@
-import { parseActivityCode, type Activity } from '@wca/helpers';
+import { parseActivityCode } from '@wca/helpers';
 import { roomByActivity, type Constraint } from 'wca-group-generators';
 
+type Activity = Parameters<Constraint['score']>[0]['activity'];
+
 const DEFAULT_KEY_STAFF_ROLES = ['delegate', 'trainee-delegate', 'organizer'];
+const DEFAULT_GAP_CAP_MINUTES = 120;
+const DEFAULT_NO_GAP_PENALTY = 100;
 
 const isStaffAssignmentCode = (assignmentCode: string) => assignmentCode.startsWith('staff-');
+const isCompetitorAssignmentCode = (assignmentCode: string) => assignmentCode === 'competitor';
 
 const firstNameFor = (name: string) => name.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
 
@@ -51,6 +56,103 @@ const earliestStaffActivityForPerson = (
       .filter(Boolean) ?? [];
 
   return (staffActivities as Activity[]).sort((a, b) => a.startTime.localeCompare(b.startTime))[0];
+};
+
+const minutesBetween = (before: Activity, after: Activity) =>
+  (new Date(after.startTime).getTime() - new Date(before.endTime).getTime()) / 60000;
+
+const gapScore = (minutes: number, gapCapMinutes: number, noGapPenalty: number) =>
+  minutes > 0 ? Math.min(minutes, gapCapMinutes) / gapCapMinutes : -noGapPenalty;
+
+const activitiesOverlap = (first: Activity, second: Activity) =>
+  new Date(first.startTime) < new Date(second.endTime) &&
+  new Date(second.startTime) < new Date(first.endTime);
+
+const assignmentActivitiesForPerson = (
+  wcif: Parameters<Constraint['score']>[0]['wcif'],
+  person: Parameters<Constraint['score']>[0]['person'],
+  assignmentTest: (assignmentCode: string) => boolean
+) => {
+  const allActivities = wcif.schedule.venues.flatMap((venue) =>
+    venue.rooms.flatMap((room) =>
+      room.activities.flatMap((activity) => [activity, ...(activity.childActivities ?? [])])
+    )
+  );
+
+  return (
+    person.assignments
+      ?.filter((assignment) => assignmentTest(assignment.assignmentCode))
+      .map((assignment) => allActivities.find((activity) => activity.id === assignment.activityId))
+      .filter(Boolean) as Activity[]
+  ).sort((a, b) => a.startTime.localeCompare(b.startTime));
+};
+
+const nearestAssignmentGapScore = (
+  activity: Activity,
+  activities: Activity[],
+  gapCapMinutes: number,
+  noGapPenalty: number
+) => {
+  if (!activities.length) {
+    return 0;
+  }
+
+  return Math.min(
+    ...activities.map((otherActivity) => {
+      if (new Date(otherActivity.endTime) <= new Date(activity.startTime)) {
+        return gapScore(minutesBetween(otherActivity, activity), gapCapMinutes, noGapPenalty);
+      }
+
+      if (new Date(activity.endTime) <= new Date(otherActivity.startTime)) {
+        return gapScore(minutesBetween(activity, otherActivity), gapCapMinutes, noGapPenalty);
+      }
+
+      return -noGapPenalty;
+    })
+  );
+};
+
+const staffBeforeCompetitorGapScore = (
+  competitorActivity: Activity,
+  staffActivities: Activity[],
+  gapCapMinutes: number,
+  noGapPenalty: number
+) => {
+  const priorStaffActivities = staffActivities.filter(
+    (staffActivity) =>
+      new Date(staffActivity.startTime) < new Date(competitorActivity.startTime) ||
+      activitiesOverlap(staffActivity, competitorActivity)
+  );
+
+  return nearestAssignmentGapScore(
+    competitorActivity,
+    priorStaffActivities,
+    gapCapMinutes,
+    noGapPenalty
+  );
+};
+
+const staffBeforeFutureCompetitorGapScore = (
+  staffActivity: Activity,
+  competitorActivities: Activity[],
+  gapCapMinutes: number,
+  noGapPenalty: number
+) => {
+  const futureCompetitorActivities = competitorActivities.filter(
+    (competitorActivity) =>
+      new Date(staffActivity.startTime) < new Date(competitorActivity.startTime) ||
+      activitiesOverlap(staffActivity, competitorActivity)
+  );
+
+  if (!futureCompetitorActivities.length) {
+    return 0;
+  }
+
+  return Math.min(
+    ...futureCompetitorActivities.map((competitorActivity) =>
+      gapScore(minutesBetween(staffActivity, competitorActivity), gapCapMinutes, noGapPenalty)
+    )
+  );
 };
 
 export const shouldHelpAfterCompeting: Constraint = {
@@ -151,10 +253,50 @@ export const avoidSimilarFirstNames: Constraint = {
   },
 };
 
+export const maximizeAssignmentGaps: Constraint = {
+  name: 'Maximize Assignment Gaps',
+  score: ({ wcif, activity, assignmentCode, person, options }) => {
+    const scoredPerson = wcif.persons.find(
+      (candidate) => candidate.registrantId === person.registrantId
+    ) ?? person;
+    const gapCapMinutes = (options?.gapCapMinutes as number | undefined) ?? DEFAULT_GAP_CAP_MINUTES;
+    const noGapPenalty = (options?.noGapPenalty as number | undefined) ?? DEFAULT_NO_GAP_PENALTY;
+    const staffActivities = assignmentActivitiesForPerson(
+      wcif,
+      scoredPerson,
+      isStaffAssignmentCode
+    );
+    const competitorActivities = assignmentActivitiesForPerson(
+      wcif,
+      scoredPerson,
+      isCompetitorAssignmentCode
+    );
+
+    if (isCompetitorAssignmentCode(assignmentCode)) {
+      return (
+        staffBeforeCompetitorGapScore(activity, staffActivities, gapCapMinutes, noGapPenalty) +
+        nearestAssignmentGapScore(activity, competitorActivities, gapCapMinutes, noGapPenalty)
+      );
+    }
+
+    if (isStaffAssignmentCode(assignmentCode)) {
+      return staffBeforeFutureCompetitorGapScore(
+        activity,
+        competitorActivities,
+        gapCapMinutes,
+        noGapPenalty
+      );
+    }
+
+    return 0;
+  },
+};
+
 export const RecipeConstraints: Record<string, Constraint> = {
   shouldHelpAfterCompeting,
   preferLaterGroups,
   mustNotHaveRoles,
   onlyMultipleGroupRounds,
   avoidSimilarFirstNames,
+  maximizeAssignmentGaps,
 };

--- a/src/lib/recipes/globalScoring.test.ts
+++ b/src/lib/recipes/globalScoring.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { Activity, AssignmentCode, Person } from '@wca/helpers';
+import type { Constraint } from 'wca-group-generators';
+import {
+  buildActivity,
+  buildPerson,
+  buildWcif,
+} from '../../store/reducers/_tests_/helpers';
+import { optimizeAssignmentsGlobally } from './globalScoring';
+
+const assignmentCode: AssignmentCode = 'competitor';
+
+const assignment = (activityId: number) => ({
+  activityId,
+  assignmentCode,
+  stationNumber: null,
+});
+
+const activity = (id: number, groupNumber: number): Activity =>
+  buildActivity({
+    id,
+    name: `Group ${groupNumber}`,
+    activityCode: `333-r1-g${groupNumber}`,
+  });
+
+const person = (registrantId: number, name: string, activityId?: number): Person =>
+  buildPerson({
+    registrantId,
+    name,
+    assignments: activityId ? [assignment(activityId)] : [],
+  });
+
+const preferredActivity: Constraint = {
+  name: 'Preferred Activity',
+  score: ({ person, activity }) => {
+    if (person.name.includes('One')) {
+      return activity.id === 101 ? 1 : 0;
+    }
+
+    if (person.name.includes('Two')) {
+      return activity.id === 102 ? 1 : 0;
+    }
+
+    return 0;
+  },
+};
+
+const onePersonPerActivity: Constraint = {
+  name: 'One Person Per Activity',
+  score: ({ wcif, activity, assignmentCode }) => {
+    const peopleInActivity = wcif.persons.filter((candidate) =>
+      candidate.assignments?.some(
+        (assignment) =>
+          assignment.assignmentCode === assignmentCode && assignment.activityId === activity.id
+      )
+    );
+
+    return peopleInActivity.length > 0 ? null : 0;
+  },
+};
+
+describe('global recipe scoring', () => {
+  it('can repair an invalid full assignment score', () => {
+    const activities = [activity(101, 1), activity(102, 2)];
+    const beforePeople = [person(1, 'Person One'), person(2, 'Person Two')];
+    const generatedPeople = [person(1, 'Person One', 101), person(2, 'Person Two', 101)];
+
+    const optimizedWcif = optimizeAssignmentsGlobally({
+      beforeWcif: buildWcif(activities, beforePeople),
+      wcif: buildWcif(activities, generatedPeople),
+      cluster: beforePeople,
+      activities,
+      assignmentCode,
+      constraints: [{ constraint: onePersonPerActivity, weight: 1 }],
+    });
+
+    const assignedActivityIds = optimizedWcif.persons.flatMap(
+      (candidate) => candidate.assignments?.map((personAssignment) => personAssignment.activityId) ?? []
+    );
+
+    expect(new Set(assignedActivityIds)).toEqual(new Set([101, 102]));
+  });
+
+  it('improves the full assignment score with swaps when single moves are illegal', () => {
+    const activities = [activity(101, 1), activity(102, 2)];
+    const beforePeople = [person(1, 'Person One'), person(2, 'Person Two')];
+    const generatedPeople = [person(1, 'Person One', 102), person(2, 'Person Two', 101)];
+
+    const optimizedWcif = optimizeAssignmentsGlobally({
+      beforeWcif: buildWcif(activities, beforePeople),
+      wcif: buildWcif(activities, generatedPeople),
+      cluster: beforePeople,
+      activities,
+      assignmentCode,
+      constraints: [
+        { constraint: onePersonPerActivity, weight: 1 },
+        { constraint: preferredActivity, weight: 1 },
+      ],
+    });
+
+    expect(
+      optimizedWcif.persons.find((candidate) => candidate.registrantId === 1)?.assignments
+    ).toContainEqual(assignment(101));
+    expect(
+      optimizedWcif.persons.find((candidate) => candidate.registrantId === 2)?.assignments
+    ).toContainEqual(assignment(102));
+  });
+
+  it('does not move assignments that existed before the current step', () => {
+    const activities = [activity(101, 1), activity(102, 2)];
+    const fixedPerson = person(1, 'Person One', 102);
+    const movablePerson = person(2, 'Person Two');
+
+    const optimizedWcif = optimizeAssignmentsGlobally({
+      beforeWcif: buildWcif(activities, [fixedPerson, movablePerson]),
+      wcif: buildWcif(activities, [fixedPerson, person(2, 'Person Two', 101)]),
+      cluster: [fixedPerson, movablePerson],
+      activities,
+      assignmentCode,
+      constraints: [{ constraint: preferredActivity, weight: 1 }],
+    });
+
+    expect(
+      optimizedWcif.persons.find((candidate) => candidate.registrantId === 1)?.assignments
+    ).toContainEqual(assignment(102));
+  });
+});

--- a/src/lib/recipes/globalScoring.ts
+++ b/src/lib/recipes/globalScoring.ts
@@ -10,9 +10,15 @@ interface OptimizeAssignmentsGloballyProps {
   constraints: ConstraintAndWeight[];
   options?: Record<string, unknown>;
   maxPasses?: number;
+  maxEvaluations?: number;
 }
 
 const EPSILON = 0.0001;
+const DEFAULT_MAX_EVALUATIONS = 1200;
+
+interface EvaluationBudget {
+  remaining: number;
+}
 
 const activityIdsFor = (activities: Activity[]) => new Set(activities.map((activity) => activity.id));
 
@@ -25,6 +31,16 @@ const matchingAssignment = (
     (assignment) =>
       assignment.assignmentCode === assignmentCode && activityIds.has(assignment.activityId)
   );
+
+const matchingActivityFor = (
+  activities: Activity[],
+  person: Person,
+  activityIds: Set<number>,
+  assignmentCode: AssignmentCode
+) => {
+  const assignment = matchingAssignment(person, activityIds, assignmentCode);
+  return activities.find((activity) => activity.id === assignment?.activityId);
+};
 
 const withoutMatchingAssignment = (
   person: Person,
@@ -154,6 +170,147 @@ const scoreWcif = (
   }, 0);
 };
 
+const activityCodesFor = (activities: Activity[], activityIds: number[]) => {
+  const codes = new Set<string>();
+
+  for (const activityId of activityIds) {
+    const activity = activities.find((candidate) => candidate.id === activityId);
+    if (activity) {
+      codes.add(activity.activityCode);
+    }
+  }
+
+  return codes;
+};
+
+const affectedRegistrantIds = (
+  wcif: Competition,
+  clusterRegistrantIds: Set<number>,
+  activities: Activity[],
+  activityIds: Set<number>,
+  assignmentCode: AssignmentCode,
+  changedActivityIds: number[],
+  changedRegistrantIds: number[]
+) => {
+  const changedActivityCodes = activityCodesFor(activities, changedActivityIds);
+  const ids = new Set(changedRegistrantIds);
+
+  for (const person of wcif.persons) {
+    if (!clusterRegistrantIds.has(person.registrantId)) {
+      continue;
+    }
+
+    const activity = matchingActivityFor(activities, person, activityIds, assignmentCode);
+    if (activity && changedActivityCodes.has(activity.activityCode)) {
+      ids.add(person.registrantId);
+    }
+  }
+
+  return ids;
+};
+
+const scorePeople = (
+  wcif: Competition,
+  clusterRegistrantIds: Set<number>,
+  registrantIds: Set<number>,
+  activities: Activity[],
+  assignmentCode: AssignmentCode,
+  constraints: ConstraintAndWeight[],
+  options?: Record<string, unknown>
+) => {
+  const activityIds = activityIdsFor(activities);
+
+  return [...registrantIds].reduce((total, registrantId) => {
+    if (total === Number.NEGATIVE_INFINITY) {
+      return total;
+    }
+
+    const person = wcif.persons.find((candidate) => candidate.registrantId === registrantId);
+    const activity = person
+      ? matchingActivityFor(activities, person, activityIds, assignmentCode)
+      : undefined;
+
+    if (!person || !activity) {
+      return Number.NEGATIVE_INFINITY;
+    }
+
+    const score = scoreAssignment(
+      wcif,
+      clusterRegistrantIds,
+      activities,
+      assignmentCode,
+      constraints,
+      options,
+      person,
+      activity
+    );
+
+    return score === null ? Number.NEGATIVE_INFINITY : total + score;
+  }, 0);
+};
+
+const candidateScoreFor = (
+  currentWcif: Competition,
+  candidateWcif: Competition,
+  clusterRegistrantIds: Set<number>,
+  scoredRegistrantIds: Set<number>,
+  affectedIds: Set<number>,
+  activities: Activity[],
+  assignmentCode: AssignmentCode,
+  constraints: ConstraintAndWeight[],
+  options: Record<string, unknown> | undefined,
+  currentScore: number
+) => {
+  if (currentScore === Number.NEGATIVE_INFINITY) {
+    return scoreWcif(
+      candidateWcif,
+      clusterRegistrantIds,
+      scoredRegistrantIds,
+      activities,
+      assignmentCode,
+      constraints,
+      options
+    );
+  }
+
+  const currentAffectedScore = scorePeople(
+    currentWcif,
+    clusterRegistrantIds,
+    affectedIds,
+    activities,
+    assignmentCode,
+    constraints,
+    options
+  );
+  const candidateAffectedScore = scorePeople(
+    candidateWcif,
+    clusterRegistrantIds,
+    affectedIds,
+    activities,
+    assignmentCode,
+    constraints,
+    options
+  );
+
+  if (
+    currentAffectedScore === Number.NEGATIVE_INFINITY ||
+    candidateAffectedScore === Number.NEGATIVE_INFINITY
+  ) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  return currentScore - currentAffectedScore + candidateAffectedScore;
+};
+
+const consumeEvaluation = (budget: EvaluationBudget) => {
+  if (budget.remaining <= 0) {
+    return false;
+  }
+
+  budget.remaining -= 1;
+  return true;
+};
+
 const findBestMove = (
   wcif: Competition,
   clusterRegistrantIds: Set<number>,
@@ -163,7 +320,8 @@ const findBestMove = (
   assignmentCode: AssignmentCode,
   constraints: ConstraintAndWeight[],
   options: Record<string, unknown> | undefined,
-  currentScore: number
+  currentScore: number,
+  budget: EvaluationBudget
 ) => {
   const activityIds = activityIdsFor(activities);
   let bestWcif = wcif;
@@ -184,6 +342,10 @@ const findBestMove = (
         continue;
       }
 
+      if (!consumeEvaluation(budget)) {
+        return { wcif: bestWcif, score: bestScore };
+      }
+
       const candidateWcif = updateAssignmentActivity(
         wcif,
         registrantId,
@@ -191,14 +353,25 @@ const findBestMove = (
         assignmentCode,
         activity.id
       );
-      const candidateScore = scoreWcif(
+      const candidateScore = candidateScoreFor(
+        wcif,
         candidateWcif,
         clusterRegistrantIds,
         scoredRegistrantIds,
+        affectedRegistrantIds(
+          wcif,
+          clusterRegistrantIds,
+          activities,
+          activityIds,
+          assignmentCode,
+          [currentAssignment.activityId, activity.id],
+          [registrantId]
+        ),
         activities,
         assignmentCode,
         constraints,
-        options
+        options,
+        currentScore
       );
 
       if (candidateScore > bestScore + EPSILON) {
@@ -220,7 +393,8 @@ const findBestSwap = (
   assignmentCode: AssignmentCode,
   constraints: ConstraintAndWeight[],
   options: Record<string, unknown> | undefined,
-  currentScore: number
+  currentScore: number,
+  budget: EvaluationBudget
 ) => {
   const activityIds = activityIdsFor(activities);
   let bestWcif = wcif;
@@ -255,6 +429,10 @@ const findBestSwap = (
         continue;
       }
 
+      if (!consumeEvaluation(budget)) {
+        return { wcif: bestWcif, score: bestScore };
+      }
+
       const candidateWcif = updateAssignmentActivity(
         updateAssignmentActivity(
           wcif,
@@ -268,14 +446,25 @@ const findBestSwap = (
         assignmentCode,
         firstAssignment.activityId
       );
-      const candidateScore = scoreWcif(
+      const candidateScore = candidateScoreFor(
+        wcif,
         candidateWcif,
         clusterRegistrantIds,
         scoredRegistrantIds,
+        affectedRegistrantIds(
+          wcif,
+          clusterRegistrantIds,
+          activities,
+          activityIds,
+          assignmentCode,
+          [firstAssignment.activityId, secondAssignment.activityId],
+          [firstRegistrantId, secondRegistrantId]
+        ),
         activities,
         assignmentCode,
         constraints,
-        options
+        options,
+        currentScore
       );
 
       if (candidateScore > bestScore + EPSILON) {
@@ -297,6 +486,7 @@ export const optimizeAssignmentsGlobally = ({
   constraints,
   options,
   maxPasses = 3,
+  maxEvaluations = DEFAULT_MAX_EVALUATIONS,
 }: OptimizeAssignmentsGloballyProps) => {
   if (!constraints.length || !activities.length || !cluster.length) {
     return wcif;
@@ -332,8 +522,13 @@ export const optimizeAssignmentsGlobally = ({
     constraints,
     options
   );
+  const budget = { remaining: maxEvaluations };
 
   for (let pass = 0; pass < maxPasses; pass += 1) {
+    if (budget.remaining <= 0) {
+      break;
+    }
+
     const bestMove = findBestMove(
       bestWcif,
       clusterRegistrantIds,
@@ -343,7 +538,8 @@ export const optimizeAssignmentsGlobally = ({
       assignmentCode,
       constraints,
       options,
-      bestScore
+      bestScore,
+      budget
     );
     const bestSwap = findBestSwap(
       bestMove.wcif,
@@ -354,7 +550,8 @@ export const optimizeAssignmentsGlobally = ({
       assignmentCode,
       constraints,
       options,
-      bestMove.score
+      bestMove.score,
+      budget
     );
 
     if (bestSwap.score <= bestScore + EPSILON) {

--- a/src/lib/recipes/globalScoring.ts
+++ b/src/lib/recipes/globalScoring.ts
@@ -1,0 +1,369 @@
+import type { Activity, AssignmentCode, Competition, Person } from '@wca/helpers';
+import type { ConstraintAndWeight } from 'wca-group-generators';
+
+interface OptimizeAssignmentsGloballyProps {
+  beforeWcif: Competition;
+  wcif: Competition;
+  cluster: Person[];
+  activities: Activity[];
+  assignmentCode: AssignmentCode;
+  constraints: ConstraintAndWeight[];
+  options?: Record<string, unknown>;
+  maxPasses?: number;
+}
+
+const EPSILON = 0.0001;
+
+const activityIdsFor = (activities: Activity[]) => new Set(activities.map((activity) => activity.id));
+
+const matchingAssignment = (
+  person: Person,
+  activityIds: Set<number>,
+  assignmentCode: AssignmentCode
+) =>
+  person.assignments?.find(
+    (assignment) =>
+      assignment.assignmentCode === assignmentCode && activityIds.has(assignment.activityId)
+  );
+
+const withoutMatchingAssignment = (
+  person: Person,
+  activityIds: Set<number>,
+  assignmentCode: AssignmentCode
+): Person => ({
+  ...person,
+  assignments:
+    person.assignments?.filter(
+      (assignment) =>
+        assignment.assignmentCode !== assignmentCode || !activityIds.has(assignment.activityId)
+    ) ?? [],
+});
+
+const updateAssignmentActivity = (
+  wcif: Competition,
+  registrantId: number,
+  activityIds: Set<number>,
+  assignmentCode: AssignmentCode,
+  activityId: number
+): Competition => ({
+  ...wcif,
+  persons: wcif.persons.map((person) => {
+    if (person.registrantId !== registrantId) {
+      return person;
+    }
+
+    const nextAssignments =
+      person.assignments?.map((assignment) =>
+        assignment.assignmentCode === assignmentCode && activityIds.has(assignment.activityId)
+          ? { ...assignment, activityId }
+          : assignment
+      ) ?? [];
+
+    return {
+      ...person,
+      assignments: matchingAssignment(person, activityIds, assignmentCode)
+        ? nextAssignments
+        : [...nextAssignments, { activityId, assignmentCode, stationNumber: null }],
+    };
+  }),
+});
+
+const scoreAssignment = (
+  wcif: Competition,
+  clusterRegistrantIds: Set<number>,
+  activities: Activity[],
+  assignmentCode: AssignmentCode,
+  constraints: ConstraintAndWeight[],
+  options: Record<string, unknown> | undefined,
+  person: Person,
+  activity: Activity
+) => {
+  const activityIds = activityIdsFor(activities);
+  const personWithoutAssignment = withoutMatchingAssignment(person, activityIds, assignmentCode);
+  const wcifWithoutAssignment = {
+    ...wcif,
+    persons: wcif.persons.map((candidate) =>
+      candidate.registrantId === person.registrantId ? personWithoutAssignment : candidate
+    ),
+  };
+  const updatedCluster = wcifWithoutAssignment.persons.filter((candidate) =>
+    clusterRegistrantIds.has(candidate.registrantId)
+  );
+
+  return constraints.reduce<number | null>((total, { constraint, weight, options: constraintOptions }) => {
+    if (total === null) {
+      return null;
+    }
+
+    const score = constraint.score({
+      wcif: wcifWithoutAssignment,
+      activities,
+      cluster: updatedCluster,
+      assignmentCode,
+      person: personWithoutAssignment,
+      activity,
+      options: {
+        ...options,
+        ...constraintOptions,
+      },
+    });
+
+    return score === null ? null : total + score * weight;
+  }, 0);
+};
+
+const scoreWcif = (
+  wcif: Competition,
+  clusterRegistrantIds: Set<number>,
+  scoredRegistrantIds: Set<number>,
+  activities: Activity[],
+  assignmentCode: AssignmentCode,
+  constraints: ConstraintAndWeight[],
+  options?: Record<string, unknown>
+) => {
+  const activityIds = activityIdsFor(activities);
+
+  return [...scoredRegistrantIds].reduce((total, registrantId) => {
+    if (total === Number.NEGATIVE_INFINITY) {
+      return total;
+    }
+
+    const person = wcif.persons.find((candidate) => candidate.registrantId === registrantId);
+    if (!person) {
+      return total;
+    }
+
+    const assignment = matchingAssignment(person, activityIds, assignmentCode);
+    const activity = activities.find((candidate) => candidate.id === assignment?.activityId);
+    if (!assignment || !activity) {
+      return Number.NEGATIVE_INFINITY;
+    }
+
+    const assignmentScore = scoreAssignment(
+      wcif,
+      clusterRegistrantIds,
+      activities,
+      assignmentCode,
+      constraints,
+      options,
+      person,
+      activity
+    );
+
+    return assignmentScore === null ? Number.NEGATIVE_INFINITY : total + assignmentScore;
+  }, 0);
+};
+
+const findBestMove = (
+  wcif: Competition,
+  clusterRegistrantIds: Set<number>,
+  scoredRegistrantIds: Set<number>,
+  movableRegistrantIds: number[],
+  activities: Activity[],
+  assignmentCode: AssignmentCode,
+  constraints: ConstraintAndWeight[],
+  options: Record<string, unknown> | undefined,
+  currentScore: number
+) => {
+  const activityIds = activityIdsFor(activities);
+  let bestWcif = wcif;
+  let bestScore = currentScore;
+
+  for (const registrantId of movableRegistrantIds) {
+    const person = wcif.persons.find((candidate) => candidate.registrantId === registrantId);
+    const currentAssignment = person
+      ? matchingAssignment(person, activityIds, assignmentCode)
+      : undefined;
+
+    if (!person || !currentAssignment) {
+      continue;
+    }
+
+    for (const activity of activities) {
+      if (activity.id === currentAssignment.activityId) {
+        continue;
+      }
+
+      const candidateWcif = updateAssignmentActivity(
+        wcif,
+        registrantId,
+        activityIds,
+        assignmentCode,
+        activity.id
+      );
+      const candidateScore = scoreWcif(
+        candidateWcif,
+        clusterRegistrantIds,
+        scoredRegistrantIds,
+        activities,
+        assignmentCode,
+        constraints,
+        options
+      );
+
+      if (candidateScore > bestScore + EPSILON) {
+        bestWcif = candidateWcif;
+        bestScore = candidateScore;
+      }
+    }
+  }
+
+  return { wcif: bestWcif, score: bestScore };
+};
+
+const findBestSwap = (
+  wcif: Competition,
+  clusterRegistrantIds: Set<number>,
+  scoredRegistrantIds: Set<number>,
+  movableRegistrantIds: number[],
+  activities: Activity[],
+  assignmentCode: AssignmentCode,
+  constraints: ConstraintAndWeight[],
+  options: Record<string, unknown> | undefined,
+  currentScore: number
+) => {
+  const activityIds = activityIdsFor(activities);
+  let bestWcif = wcif;
+  let bestScore = currentScore;
+
+  for (let firstIndex = 0; firstIndex < movableRegistrantIds.length; firstIndex += 1) {
+    for (
+      let secondIndex = firstIndex + 1;
+      secondIndex < movableRegistrantIds.length;
+      secondIndex += 1
+    ) {
+      const firstRegistrantId = movableRegistrantIds[firstIndex];
+      const secondRegistrantId = movableRegistrantIds[secondIndex];
+      const firstPerson = wcif.persons.find(
+        (candidate) => candidate.registrantId === firstRegistrantId
+      );
+      const secondPerson = wcif.persons.find(
+        (candidate) => candidate.registrantId === secondRegistrantId
+      );
+      const firstAssignment = firstPerson
+        ? matchingAssignment(firstPerson, activityIds, assignmentCode)
+        : undefined;
+      const secondAssignment = secondPerson
+        ? matchingAssignment(secondPerson, activityIds, assignmentCode)
+        : undefined;
+
+      if (
+        !firstAssignment ||
+        !secondAssignment ||
+        firstAssignment.activityId === secondAssignment.activityId
+      ) {
+        continue;
+      }
+
+      const candidateWcif = updateAssignmentActivity(
+        updateAssignmentActivity(
+          wcif,
+          firstRegistrantId,
+          activityIds,
+          assignmentCode,
+          secondAssignment.activityId
+        ),
+        secondRegistrantId,
+        activityIds,
+        assignmentCode,
+        firstAssignment.activityId
+      );
+      const candidateScore = scoreWcif(
+        candidateWcif,
+        clusterRegistrantIds,
+        scoredRegistrantIds,
+        activities,
+        assignmentCode,
+        constraints,
+        options
+      );
+
+      if (candidateScore > bestScore + EPSILON) {
+        bestWcif = candidateWcif;
+        bestScore = candidateScore;
+      }
+    }
+  }
+
+  return { wcif: bestWcif, score: bestScore };
+};
+
+export const optimizeAssignmentsGlobally = ({
+  beforeWcif,
+  wcif,
+  cluster,
+  activities,
+  assignmentCode,
+  constraints,
+  options,
+  maxPasses = 3,
+}: OptimizeAssignmentsGloballyProps) => {
+  if (!constraints.length || !activities.length || !cluster.length) {
+    return wcif;
+  }
+
+  const activityIds = activityIdsFor(activities);
+  const clusterRegistrantIds = new Set(cluster.map((person) => person.registrantId));
+  const scoredRegistrantIds = new Set(
+    wcif.persons
+      .filter(
+        (person) =>
+          clusterRegistrantIds.has(person.registrantId) &&
+          matchingAssignment(person, activityIds, assignmentCode)
+      )
+      .map((person) => person.registrantId)
+  );
+  const movableRegistrantIds = [...scoredRegistrantIds].filter((registrantId) => {
+    const beforePerson = beforeWcif.persons.find((person) => person.registrantId === registrantId);
+    return beforePerson ? !matchingAssignment(beforePerson, activityIds, assignmentCode) : true;
+  });
+
+  if (!movableRegistrantIds.length) {
+    return wcif;
+  }
+
+  let bestWcif = wcif;
+  let bestScore = scoreWcif(
+    bestWcif,
+    clusterRegistrantIds,
+    scoredRegistrantIds,
+    activities,
+    assignmentCode,
+    constraints,
+    options
+  );
+
+  for (let pass = 0; pass < maxPasses; pass += 1) {
+    const bestMove = findBestMove(
+      bestWcif,
+      clusterRegistrantIds,
+      scoredRegistrantIds,
+      movableRegistrantIds,
+      activities,
+      assignmentCode,
+      constraints,
+      options,
+      bestScore
+    );
+    const bestSwap = findBestSwap(
+      bestMove.wcif,
+      clusterRegistrantIds,
+      scoredRegistrantIds,
+      movableRegistrantIds,
+      activities,
+      assignmentCode,
+      constraints,
+      options,
+      bestMove.score
+    );
+
+    if (bestSwap.score <= bestScore + EPSILON) {
+      break;
+    }
+
+    bestWcif = bestSwap.wcif;
+    bestScore = bestSwap.score;
+  }
+
+  return bestWcif;
+};

--- a/src/lib/recipes/index.ts
+++ b/src/lib/recipes/index.ts
@@ -1,6 +1,7 @@
 export * from './activities';
 export * from './clusters';
 export * from './constraints';
+export * from './globalScoring';
 export * from './recipes';
 export * from './steps';
 export * from './types';

--- a/src/lib/recipes/index.ts
+++ b/src/lib/recipes/index.ts
@@ -1,5 +1,6 @@
 export * from './activities';
 export * from './clusters';
+export * from './constraints';
 export * from './recipes';
 export * from './steps';
 export * from './types';

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -1,6 +1,6 @@
-import { ActivityCode, Competition, Event, EventId, Round, parseActivityCode } from '@wca/helpers';
+import type { ActivityCode, Competition, Round } from '@wca/helpers';
 import { StepLibrary, fromDefaults } from './steps';
-import { RecipeConfig, RecipeDefinition, Step } from './types';
+import type { RecipeConfig, RecipeDefinition, Step } from './types';
 
 export const Recipes: RecipeDefinition[] = [
   {
@@ -19,17 +19,13 @@ export const Recipes: RecipeDefinition[] = [
     name: 'PNW',
     description: 'PNW',
     defaultSteps: [
+      StepLibrary.GenerateSingleGroupForFinal,
       StepLibrary.GenerateCompetitorAssignmentsForStaff,
+      StepLibrary.GenerateCompetitorAssignmentsForDelegatesAndOrganizers,
       StepLibrary.GenerateCompetitorAssignmentsForFirstTimers,
       StepLibrary.GenerateCompetitorAssignments,
       StepLibrary.GenerateJudgeAssignmentsForCompetitors,
     ],
-  },
-  {
-    id: '1-group-finals',
-    name: '1 group final',
-    description: 'Makes a single group of competitors for finals',
-    defaultSteps: [StepLibrary.GenerateSingleGroup, StepLibrary.GenerateCompetitorAssignments],
   },
   {
     id: 'mca',
@@ -55,17 +51,6 @@ export const fromRecipeDefinition = (
   steps: recipe.defaultSteps.map((step) => fromDefaults(step, { wcif, activityCode })) as Step[],
 });
 
-export const getPreferredDefaultRecipe = (wcif: Competition, round: Round) => {
-  const { eventId } = parseActivityCode(round.id) as { eventId: EventId; roundNumber: number };
-
-  const event = wcif.events.find((event) => event.id === eventId) as Event;
-
-  const rounds = event.rounds.map((round) => round.id).sort();
-
-  // Is last round?
-  if (rounds[rounds.length - 1] === round.id) {
-    return 'pnw-1-group-finals';
-  }
-
+export const getPreferredDefaultRecipe = (_wcif: Competition, _round: Round) => {
   return 'pnw';
 };

--- a/src/lib/recipes/runRecipeOnWcif.ts
+++ b/src/lib/recipes/runRecipeOnWcif.ts
@@ -13,6 +13,7 @@ import {
   setRoundConfigExtensionData,
 } from '../wcif/extensions/delegateDashboard/delegateDashboard';
 import { mapIn } from '../utils/utils';
+import { countPeopleWithImmediateHelpingThenCompetingAssignments } from './bulkGenerationDiagnostics';
 import { shouldRunGroupStep } from './conditions';
 import { RecipeConstraints } from './constraints';
 import { optimizeAssignmentsGlobally } from './globalScoring';
@@ -305,5 +306,13 @@ export const runBulkRecipesOnWcif = (
     });
   }
 
-  return setRoundRecipeConfigs(generatedWcif, roundIds, recipeId);
+  const completedWcif = setRoundRecipeConfigs(generatedWcif, roundIds, recipeId);
+
+  // eslint-disable-next-line no-console
+  console.debug(
+    '[BulkGeneration] competitors with immediate helping -> competing assignments:',
+    countPeopleWithImmediateHelpingThenCompetingAssignments(completedWcif)
+  );
+
+  return completedWcif;
 };

--- a/src/lib/recipes/runRecipeOnWcif.ts
+++ b/src/lib/recipes/runRecipeOnWcif.ts
@@ -1,0 +1,309 @@
+import type { Activity, AssignmentCode, Competition, Person } from '@wca/helpers';
+import {
+  Constraints,
+  Generators,
+  type Constraint,
+  type ConstraintAndWeight,
+  type Generator,
+} from 'wca-group-generators';
+import { findRoundActivitiesById } from '../wcif/activities';
+import { createGroupsAcrossStages } from '../wcif/groups';
+import {
+  getRoundConfigExtensionData,
+  setRoundConfigExtensionData,
+} from '../wcif/extensions/delegateDashboard/delegateDashboard';
+import { mapIn } from '../utils/utils';
+import { shouldRunGroupStep } from './conditions';
+import { RecipeConstraints } from './constraints';
+import { optimizeAssignmentsGlobally } from './globalScoring';
+import { Recipes, fromRecipeDefinition } from './recipes';
+import { hydrateStep } from './steps';
+import type { AssignmentStep, ConstraintProps, Step } from './types';
+
+export interface RunRecipeOnWcifPayload {
+  roundId: string;
+  recipeId: string;
+}
+
+export interface RunRecipesOnWcifPayload {
+  roundIds: string[];
+  recipeId: string;
+}
+
+export interface BulkGenerationProgress {
+  phase: 'generating' | 'fixing' | 'staff';
+  roundId?: string;
+}
+
+interface OptimizationContext {
+  roundId: string;
+  stepId: string;
+  cluster: Person[];
+  activities: Activity[];
+  assignmentCode: AssignmentCode;
+  constraints: ConstraintAndWeight[];
+  options?: Record<string, unknown>;
+  maxPasses?: number;
+  maxEvaluations?: number;
+  maxClusterSize?: number;
+}
+
+interface RunRecipeStepsOnWcifPayload extends RunRecipeOnWcifPayload {
+  stepFilter?: (step: Step) => boolean;
+  onOptimizationContext?: (context: OptimizationContext) => void;
+}
+
+const isCompetitorAssignmentStep = (step: Step) =>
+  step.type === 'assignments' && step.props.assignmentCode === 'competitor';
+
+const isStaffAssignmentStep = (step: Step) =>
+  step.type === 'assignments' && step.props.assignmentCode !== 'competitor';
+
+const setRoundRecipeConfig = (
+  wcif: Competition,
+  roundId: string,
+  recipeId: string
+): Competition => ({
+  ...wcif,
+  events: wcif.events.map((event) => ({
+    ...event,
+    rounds: event.rounds.map((round) => {
+      if (round.id !== roundId) {
+        return round;
+      }
+
+      return setRoundConfigExtensionData(round, {
+        ...(getRoundConfigExtensionData(round) ?? {}),
+        recipe: { id: recipeId },
+      });
+    }),
+  })),
+});
+
+const setRoundRecipeConfigs = (wcif: Competition, roundIds: string[], recipeId: string) =>
+  roundIds.reduce(
+    (accWcif, roundId) => setRoundRecipeConfig(accWcif, roundId, recipeId),
+    wcif
+  );
+
+const resolveConstraints = (constraints: ConstraintProps[] | undefined): ConstraintAndWeight[] =>
+  constraints?.map((constraintConfig) => {
+    const constraintFn =
+      (RecipeConstraints as Record<string, Constraint | undefined>)[constraintConfig.constraint] ??
+      (Constraints as unknown as Record<string, Constraint | undefined>)[
+        constraintConfig.constraint
+      ];
+    if (!constraintFn) {
+      throw new Error(`Constraint ${constraintConfig.constraint} not found`);
+    }
+    return {
+      constraint: constraintFn,
+      weight: constraintConfig.weight,
+      options: constraintConfig.options,
+    };
+  }) ?? [];
+
+const runAssignmentStepOnWcif = (
+  wcif: Competition,
+  roundId: string,
+  step: AssignmentStep,
+  onOptimizationContext?: (context: OptimizationContext) => void
+) => {
+  const generator = (Generators as unknown as Record<string, Generator | undefined>)[
+    step.props.generator
+  ];
+  if (!generator) {
+    throw new Error(`Generator ${step.props.generator} not found`);
+  }
+
+  const hydratedStep = hydrateStep(wcif, roundId, step);
+  const constraints = resolveConstraints(hydratedStep.props.constraints);
+
+  if (hydratedStep.props.globalScore) {
+    onOptimizationContext?.({
+      roundId,
+      stepId: hydratedStep.id,
+      cluster: hydratedStep.props.cluster,
+      activities: hydratedStep.props.activities,
+      assignmentCode: hydratedStep.props.assignmentCode,
+      constraints,
+      options: hydratedStep.props.options,
+      maxPasses: hydratedStep.props.globalScore.maxPasses,
+      maxEvaluations: hydratedStep.props.globalScore.maxEvaluations,
+      maxClusterSize: hydratedStep.props.globalScore.maxClusterSize,
+    });
+  }
+
+  const generatedWcif = generator.execute({
+    wcif,
+    roundId,
+    ...hydratedStep.props,
+    constraints,
+  }) as Competition;
+
+  if (!hydratedStep.props.globalScore) {
+    return generatedWcif;
+  }
+
+  if (
+    hydratedStep.props.globalScore.maxClusterSize &&
+    hydratedStep.props.cluster.length > hydratedStep.props.globalScore.maxClusterSize
+  ) {
+    return generatedWcif;
+  }
+
+  return optimizeAssignmentsGlobally({
+    beforeWcif: wcif,
+    wcif: generatedWcif,
+    cluster: hydratedStep.props.cluster,
+    activities: hydratedStep.props.activities,
+    assignmentCode: hydratedStep.props.assignmentCode,
+    constraints,
+    options: hydratedStep.props.options,
+    maxPasses: hydratedStep.props.globalScore.maxPasses,
+    maxEvaluations: hydratedStep.props.globalScore.maxEvaluations,
+  });
+};
+
+const runGroupStepOnWcif = (wcif: Competition, roundId: string, step: Step) => {
+  if (step.type !== 'groups') {
+    return wcif;
+  }
+
+  const roundActivities = findRoundActivitiesById(wcif, roundId);
+  if (!shouldRunGroupStep(wcif, roundId, roundActivities, step)) {
+    return wcif;
+  }
+
+  const roundActivitiesWithGroups = createGroupsAcrossStages(wcif, roundActivities, {
+    spreadGroupsAcrossAllStages: true,
+    groups: step.props.count,
+  });
+  const roundActivitiesWithGroupsById = new Map(
+    roundActivitiesWithGroups.map((activity) => [activity.id, activity])
+  );
+
+  return {
+    ...wcif,
+    schedule: mapIn(wcif.schedule, 'venues', (venue) =>
+      mapIn(venue, 'rooms', (room) =>
+        mapIn(room, 'activities', (activity) =>
+          roundActivitiesWithGroupsById.get(activity.id) ?? activity
+        )
+      )
+    ),
+  } as Competition;
+};
+
+const recipeStepsFor = (wcif: Competition, recipeId: string, roundId: string) => {
+  const recipeDef = Recipes.find((recipe) => recipe.id === recipeId);
+  if (!recipeDef) {
+    throw new Error(`Recipe ${recipeId} not found`);
+  }
+
+  return fromRecipeDefinition(recipeDef, { wcif, activityCode: roundId }).steps;
+};
+
+const runRecipeStepsOnWcif = (
+  wcif: Competition,
+  { roundId, recipeId, stepFilter, onOptimizationContext }: RunRecipeStepsOnWcifPayload
+): Competition =>
+  recipeStepsFor(wcif, recipeId, roundId)
+    .filter(stepFilter ?? (() => true))
+    .reduce<Competition>((accWcif, step) => {
+      if (step.type === 'assignments') {
+        return runAssignmentStepOnWcif(accWcif, roundId, step, onOptimizationContext);
+      }
+
+      return runGroupStepOnWcif(accWcif, roundId, step);
+    }, wcif);
+
+const optimizeCapturedContexts = (
+  wcif: Competition,
+  baseWcif: Competition,
+  contexts: OptimizationContext[]
+) => {
+  let optimizedWcif = wcif;
+
+  for (let pass = 0; pass < 2; pass += 1) {
+    for (const context of contexts) {
+      if (context.maxClusterSize && context.cluster.length > context.maxClusterSize) {
+        continue;
+      }
+
+      optimizedWcif = optimizeAssignmentsGlobally({
+        beforeWcif: baseWcif,
+        wcif: optimizedWcif,
+        cluster: context.cluster,
+        activities: context.activities,
+        assignmentCode: context.assignmentCode,
+        constraints: context.constraints,
+        options: context.options,
+        maxPasses: context.maxPasses,
+        maxEvaluations: context.maxEvaluations,
+      });
+    }
+  }
+
+  return optimizedWcif;
+};
+
+export const runRecipeOnWcif = (wcif: Competition, action: RunRecipeOnWcifPayload): Competition =>
+  setRoundRecipeConfig(
+    runRecipeStepsOnWcif(wcif, action),
+    action.roundId,
+    action.recipeId
+  );
+
+export const runRecipesOnWcif = (
+  wcif: Competition,
+  action: RunRecipesOnWcifPayload
+): Competition =>
+  action.roundIds.reduce(
+    (accWcif, roundId) => runRecipeOnWcif(accWcif, { roundId, recipeId: action.recipeId }),
+    wcif
+  );
+
+export const runBulkRecipesOnWcif = (
+  wcif: Competition,
+  {
+    recipeId,
+    roundIds,
+    onProgress,
+  }: RunRecipesOnWcifPayload & {
+    onProgress?: (progress: BulkGenerationProgress) => void;
+  }
+): Competition => {
+  const optimizationContexts: OptimizationContext[] = [];
+  let generatedWcif = wcif;
+
+  for (const roundId of roundIds) {
+    onProgress?.({ phase: 'generating', roundId });
+    generatedWcif = runRecipeStepsOnWcif(generatedWcif, {
+      roundId,
+      recipeId,
+      stepFilter: (step) => step.type === 'groups' || isCompetitorAssignmentStep(step),
+      onOptimizationContext: (context) => {
+        if (context.assignmentCode === 'competitor') {
+          optimizationContexts.push(context);
+        }
+      },
+    });
+  }
+
+  if (optimizationContexts.length) {
+    onProgress?.({ phase: 'fixing' });
+    generatedWcif = optimizeCapturedContexts(generatedWcif, wcif, optimizationContexts);
+  }
+
+  for (const roundId of roundIds) {
+    onProgress?.({ phase: 'staff', roundId });
+    generatedWcif = runRecipeStepsOnWcif(generatedWcif, {
+      roundId,
+      recipeId,
+      stepFilter: isStaffAssignmentStep,
+    });
+  }
+
+  return setRoundRecipeConfigs(generatedWcif, roundIds, recipeId);
+};

--- a/src/lib/recipes/runRecipeOnWcif.ts
+++ b/src/lib/recipes/runRecipeOnWcif.ts
@@ -275,7 +275,8 @@ export const runBulkRecipesOnWcif = (
     onProgress?: (progress: BulkGenerationProgress) => void;
   }
 ): Competition => {
-  const optimizationContexts: OptimizationContext[] = [];
+  const competitorOptimizationContexts: OptimizationContext[] = [];
+  const staffOptimizationContexts: OptimizationContext[] = [];
   let generatedWcif = wcif;
 
   for (const roundId of roundIds) {
@@ -286,15 +287,19 @@ export const runBulkRecipesOnWcif = (
       stepFilter: (step) => step.type === 'groups' || isCompetitorAssignmentStep(step),
       onOptimizationContext: (context) => {
         if (context.assignmentCode === 'competitor') {
-          optimizationContexts.push(context);
+          competitorOptimizationContexts.push(context);
         }
       },
     });
   }
 
-  if (optimizationContexts.length) {
+  if (competitorOptimizationContexts.length) {
     onProgress?.({ phase: 'fixing' });
-    generatedWcif = optimizeCapturedContexts(generatedWcif, wcif, optimizationContexts);
+    generatedWcif = optimizeCapturedContexts(
+      generatedWcif,
+      wcif,
+      competitorOptimizationContexts
+    );
   }
 
   for (const roundId of roundIds) {
@@ -303,7 +308,17 @@ export const runBulkRecipesOnWcif = (
       roundId,
       recipeId,
       stepFilter: isStaffAssignmentStep,
+      onOptimizationContext: (context) => {
+        if (context.assignmentCode !== 'competitor') {
+          staffOptimizationContexts.push(context);
+        }
+      },
     });
+  }
+
+  if (staffOptimizationContexts.length) {
+    onProgress?.({ phase: 'fixing' });
+    generatedWcif = optimizeCapturedContexts(generatedWcif, wcif, staffOptimizationContexts);
   }
 
   const completedWcif = setRoundRecipeConfigs(generatedWcif, roundIds, recipeId);

--- a/src/lib/recipes/steps.ts
+++ b/src/lib/recipes/steps.ts
@@ -8,10 +8,13 @@ import { AssignmentStep, StepDefinition } from './types';
 
 export const StepLibrary: Record<string, StepDefinition> = {
   GenerateSingleGroup: core.GenerateSingleGroup,
+  GenerateSingleGroupForFinal: core.GenerateSingleGroupForFinal,
   SpreadDelegates: core.SpreadDelegates,
   BalancedCompetitorAssignmentsForEveryone: core.BalancedCompetitorAssignmentsForEveryone,
   NoCompetitorAssignmentLeftBehind: core.NoCompetitorAssignmentLeftBehind,
   GenerateCompetitorAssignmentsForStaff: pnw.GenerateCompetitorAssignmentsForStaff,
+  GenerateCompetitorAssignmentsForDelegatesAndOrganizers:
+    pnw.GenerateCompetitorAssignmentsForDelegatesAndOrganizers,
   GenerateCompetitorAssignmentsForFirstTimers: pnw.GenerateCompetitorAssignmentsForFirstTimers,
   GenerateCompetitorAssignments: pnw.GenerateCompetitorAssignments,
   GenerateJudgeAssignmentsForCompetitors: pnw.GenerateJudgeAssignmentsForCompetitors,

--- a/src/lib/recipes/steps/core.ts
+++ b/src/lib/recipes/steps/core.ts
@@ -12,6 +12,19 @@ export const GenerateSingleGroup: StepDefinition = {
   }),
 };
 
+export const GenerateSingleGroupForFinal: StepDefinition = {
+  id: 'GenerateSingleGroupForFinal',
+  name: 'Generate Single Group For Final',
+  description: 'Generates one group for a final round when groups do not already exist',
+  defaults: () => ({
+    type: 'groups',
+    props: {
+      count: 1,
+      condition: 'missingGroupsInFinalRound',
+    },
+  }),
+};
+
 export const SpreadDelegates: StepDefinition = {
   id: 'SpreadDelegateCompetitorAssignments',
   name: 'Spread Delegate Competitor Assignments',

--- a/src/lib/recipes/steps/pnw.ts
+++ b/src/lib/recipes/steps/pnw.ts
@@ -20,8 +20,8 @@ export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
           },
         ],
         sort: {
-          by: 'speed',
-          direction: 'asc',
+          by: 'mostConstrained',
+          direction: 'desc',
         },
       },
       assignmentCode: 'competitor',
@@ -93,8 +93,8 @@ export const GenerateCompetitorAssignmentsForDelegatesAndOrganizers: StepDefinit
           },
         ],
         sort: {
-          by: 'speed',
-          direction: 'asc',
+          by: 'mostConstrained',
+          direction: 'desc',
         },
       },
       assignmentCode: 'competitor',
@@ -156,8 +156,8 @@ export const GenerateCompetitorAssignmentsForFirstTimers: StepDefinition = {
           },
         ],
         sort: {
-          by: 'speed',
-          direction: 'asc',
+          by: 'mostConstrained',
+          direction: 'desc',
         },
       },
       assignmentCode: 'competitor',
@@ -208,8 +208,8 @@ export const GenerateCompetitorAssignments: StepDefinition = {
           },
         ],
         sort: {
-          by: 'speed',
-          direction: 'asc',
+          by: 'mostConstrained',
+          direction: 'desc',
         },
       },
       assignmentCode: 'competitor',

--- a/src/lib/recipes/steps/pnw.ts
+++ b/src/lib/recipes/steps/pnw.ts
@@ -1,6 +1,11 @@
 import { StepDefinition } from '../types';
 
 const PNW_BALANCED_GROUP_SIZE_WEIGHT = 20;
+const PNW_ASSIGNMENT_GAP_WEIGHT = 10;
+const PNW_ASSIGNMENT_GAP_OPTIONS = {
+  gapCapMinutes: 120,
+  noGapPenalty: 100,
+};
 const PNW_GLOBAL_SCORE = {
   maxPasses: 1,
   maxEvaluations: 250,
@@ -55,6 +60,11 @@ export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
         {
           constraint: 'maximizeBreaks',
           weight: 10,
+        },
+        {
+          constraint: 'maximizeAssignmentGaps',
+          weight: PNW_ASSIGNMENT_GAP_WEIGHT,
+          options: PNW_ASSIGNMENT_GAP_OPTIONS,
         },
         {
           constraint: 'assignmentsNextToEachother',
@@ -123,6 +133,11 @@ export const GenerateCompetitorAssignmentsForDelegatesAndOrganizers: StepDefinit
           weight: 20,
         },
         {
+          constraint: 'maximizeAssignmentGaps',
+          weight: PNW_ASSIGNMENT_GAP_WEIGHT,
+          options: PNW_ASSIGNMENT_GAP_OPTIONS,
+        },
+        {
           constraint: 'balancedGroupNumberSize',
           weight: 15,
           options: {
@@ -183,6 +198,11 @@ export const GenerateCompetitorAssignmentsForFirstTimers: StepDefinition = {
           weight: 1,
         },
         {
+          constraint: 'maximizeAssignmentGaps',
+          weight: PNW_ASSIGNMENT_GAP_WEIGHT,
+          options: PNW_ASSIGNMENT_GAP_OPTIONS,
+        },
+        {
           constraint: 'avoidConflictingNames',
           weight: 1,
         },
@@ -234,6 +254,11 @@ export const GenerateCompetitorAssignments: StepDefinition = {
         {
           constraint: 'mustNotHaveOtherAssignments',
           weight: 1,
+        },
+        {
+          constraint: 'maximizeAssignmentGaps',
+          weight: PNW_ASSIGNMENT_GAP_WEIGHT,
+          options: PNW_ASSIGNMENT_GAP_OPTIONS,
         },
         {
           constraint: 'avoidConflictingNames',
@@ -310,6 +335,11 @@ export const GenerateJudgeAssignmentsForCompetitors: StepDefinition = {
         {
           constraint: 'sameStageAsOtherAssignments',
           weight: 5,
+        },
+        {
+          constraint: 'maximizeAssignmentGaps',
+          weight: PNW_ASSIGNMENT_GAP_WEIGHT,
+          options: PNW_ASSIGNMENT_GAP_OPTIONS,
         },
         {
           constraint: 'shouldFollowCompetitorAssignment',

--- a/src/lib/recipes/steps/pnw.ts
+++ b/src/lib/recipes/steps/pnw.ts
@@ -1,6 +1,9 @@
 import { StepDefinition } from '../types';
 
 const PNW_BALANCED_GROUP_SIZE_WEIGHT = 20;
+const PNW_GLOBAL_SCORE = {
+  maxPasses: 3,
+};
 
 export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
   id: 'GenerateCompetitorAssignmentsForStaff',
@@ -29,6 +32,7 @@ export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
       options: {
         mode: 'symmetric',
       },
+      globalScore: PNW_GLOBAL_SCORE,
       constraints: [
         {
           constraint: 'uniqueAssignment',
@@ -102,6 +106,7 @@ export const GenerateCompetitorAssignmentsForDelegatesAndOrganizers: StepDefinit
       options: {
         mode: 'symmetric',
       },
+      globalScore: PNW_GLOBAL_SCORE,
       constraints: [
         {
           constraint: 'uniqueAssignment',
@@ -165,6 +170,7 @@ export const GenerateCompetitorAssignmentsForFirstTimers: StepDefinition = {
       options: {
         mode: 'symmetric',
       },
+      globalScore: PNW_GLOBAL_SCORE,
       constraints: [
         {
           constraint: 'uniqueAssignment',
@@ -217,6 +223,7 @@ export const GenerateCompetitorAssignments: StepDefinition = {
       options: {
         mode: 'symmetric',
       },
+      globalScore: PNW_GLOBAL_SCORE,
       constraints: [
         {
           constraint: 'uniqueAssignment',
@@ -278,6 +285,7 @@ export const GenerateJudgeAssignmentsForCompetitors: StepDefinition = {
       options: {
         mode: 'symmetric',
       },
+      globalScore: PNW_GLOBAL_SCORE,
       constraints: [
         {
           constraint: 'uniqueAssignment',

--- a/src/lib/recipes/steps/pnw.ts
+++ b/src/lib/recipes/steps/pnw.ts
@@ -11,6 +11,15 @@ const PNW_GLOBAL_SCORE = {
   maxEvaluations: 250,
   maxClusterSize: 80,
 };
+const PNW_STAFF_GLOBAL_SCORE = {
+  maxPasses: 1,
+  maxEvaluations: 300,
+  maxClusterSize: 90,
+};
+const avoidImmediateHelpingThenCompetingConstraint = () => ({
+  constraint: 'avoidImmediateHelpingThenCompeting',
+  weight: 1,
+});
 
 export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
   id: 'GenerateCompetitorAssignmentsForStaff',
@@ -49,6 +58,7 @@ export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
           constraint: 'mustNotHaveOtherAssignments',
           weight: 1,
         },
+        avoidImmediateHelpingThenCompetingConstraint(),
         {
           constraint: 'shouldHelpAfterCompeting',
           weight: 20,
@@ -128,6 +138,7 @@ export const GenerateCompetitorAssignmentsForDelegatesAndOrganizers: StepDefinit
           constraint: 'mustNotHaveOtherAssignments',
           weight: 1,
         },
+        avoidImmediateHelpingThenCompetingConstraint(),
         {
           constraint: 'preferLaterGroups',
           weight: 20,
@@ -197,6 +208,7 @@ export const GenerateCompetitorAssignmentsForFirstTimers: StepDefinition = {
           constraint: 'mustNotHaveOtherAssignments',
           weight: 1,
         },
+        avoidImmediateHelpingThenCompetingConstraint(),
         {
           constraint: 'maximizeAssignmentGaps',
           weight: PNW_ASSIGNMENT_GAP_WEIGHT,
@@ -255,6 +267,7 @@ export const GenerateCompetitorAssignments: StepDefinition = {
           constraint: 'mustNotHaveOtherAssignments',
           weight: 1,
         },
+        avoidImmediateHelpingThenCompetingConstraint(),
         {
           constraint: 'maximizeAssignmentGaps',
           weight: PNW_ASSIGNMENT_GAP_WEIGHT,
@@ -312,6 +325,7 @@ export const GenerateJudgeAssignmentsForCompetitors: StepDefinition = {
       options: {
         mode: 'symmetric',
       },
+      globalScore: PNW_STAFF_GLOBAL_SCORE,
       constraints: [
         {
           constraint: 'uniqueAssignment',
@@ -321,6 +335,7 @@ export const GenerateJudgeAssignmentsForCompetitors: StepDefinition = {
           constraint: 'mustNotHaveOtherAssignments',
           weight: 1,
         },
+        avoidImmediateHelpingThenCompetingConstraint(),
         {
           constraint: 'onlyMultipleGroupRounds',
           weight: 1,

--- a/src/lib/recipes/steps/pnw.ts
+++ b/src/lib/recipes/steps/pnw.ts
@@ -1,5 +1,7 @@
 import { StepDefinition } from '../types';
 
+const PNW_BALANCED_GROUP_SIZE_WEIGHT = 20;
+
 export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
   id: 'GenerateCompetitorAssignmentsForStaff',
   name: 'Generate Competitor Assignments For Staff',
@@ -37,6 +39,10 @@ export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
           weight: 1,
         },
         {
+          constraint: 'shouldHelpAfterCompeting',
+          weight: 20,
+        },
+        {
           constraint: 'sameStageAsOtherAssignments',
           weight: 5,
         },
@@ -51,6 +57,82 @@ export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
         {
           constraint: 'avoidConflictingNames',
           weight: 10,
+        },
+        {
+          constraint: 'avoidSimilarFirstNames',
+          weight: 10,
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: PNW_BALANCED_GROUP_SIZE_WEIGHT,
+        },
+      ],
+    },
+  }),
+};
+
+export const GenerateCompetitorAssignmentsForDelegatesAndOrganizers: StepDefinition = {
+  id: 'GenerateCompetitorAssignmentsForDelegatesAndOrganizers',
+  name: 'Generate Competitor Assignments For Delegates And Organizers',
+  description:
+    'Generates competitor assignments for delegates and organizers, preferring later groups first',
+  defaults: () => ({
+    type: 'assignments',
+    props: {
+      generator: 'assignEveryone',
+      cluster: {
+        base: 'personsInRound',
+        filters: [
+          {
+            key: 'hasRole',
+            value: ['delegate', 'trainee-delegate', 'organizer'],
+          },
+          {
+            key: 'doesNotHaveAssignmentInRound',
+            value: 'competitor',
+          },
+        ],
+        sort: {
+          by: 'speed',
+          direction: 'asc',
+        },
+      },
+      assignmentCode: 'competitor',
+      activities: { base: 'all' },
+      options: {
+        mode: 'symmetric',
+      },
+      constraints: [
+        {
+          constraint: 'uniqueAssignment',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveOtherAssignments',
+          weight: 1,
+        },
+        {
+          constraint: 'preferLaterGroups',
+          weight: 20,
+        },
+        {
+          constraint: 'balancedGroupNumberSize',
+          weight: 15,
+          options: {
+            persons: 'cluster',
+          },
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: PNW_BALANCED_GROUP_SIZE_WEIGHT,
+        },
+        {
+          constraint: 'avoidConflictingNames',
+          weight: 1,
+        },
+        {
+          constraint: 'avoidSimilarFirstNames',
+          weight: 1,
         },
       ],
     },
@@ -97,8 +179,12 @@ export const GenerateCompetitorAssignmentsForFirstTimers: StepDefinition = {
           weight: 1,
         },
         {
-          constraint: 'balancedGroupSize',
+          constraint: 'avoidSimilarFirstNames',
           weight: 1,
+        },
+        {
+          constraint: 'balancedGroupSize',
+          weight: PNW_BALANCED_GROUP_SIZE_WEIGHT,
         },
       ],
     },
@@ -145,8 +231,12 @@ export const GenerateCompetitorAssignments: StepDefinition = {
           weight: 10,
         },
         {
+          constraint: 'avoidSimilarFirstNames',
+          weight: 40,
+        },
+        {
           constraint: 'balancedGroupSize',
-          weight: 5,
+          weight: PNW_BALANCED_GROUP_SIZE_WEIGHT,
         },
         {
           constraint: 'balancedSpeed',
@@ -196,6 +286,17 @@ export const GenerateJudgeAssignmentsForCompetitors: StepDefinition = {
         {
           constraint: 'mustNotHaveOtherAssignments',
           weight: 1,
+        },
+        {
+          constraint: 'onlyMultipleGroupRounds',
+          weight: 1,
+        },
+        {
+          constraint: 'mustNotHaveRoles',
+          weight: 1,
+          options: {
+            roles: ['delegate', 'trainee-delegate', 'organizer'],
+          },
         },
         {
           constraint: 'sameStageAsOtherAssignments',

--- a/src/lib/recipes/steps/pnw.ts
+++ b/src/lib/recipes/steps/pnw.ts
@@ -2,7 +2,8 @@ import { StepDefinition } from '../types';
 
 const PNW_BALANCED_GROUP_SIZE_WEIGHT = 20;
 const PNW_GLOBAL_SCORE = {
-  maxPasses: 3,
+  maxPasses: 1,
+  maxEvaluations: 1200,
 };
 
 export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {

--- a/src/lib/recipes/steps/pnw.ts
+++ b/src/lib/recipes/steps/pnw.ts
@@ -3,7 +3,8 @@ import { StepDefinition } from '../types';
 const PNW_BALANCED_GROUP_SIZE_WEIGHT = 20;
 const PNW_GLOBAL_SCORE = {
   maxPasses: 1,
-  maxEvaluations: 1200,
+  maxEvaluations: 250,
+  maxClusterSize: 80,
 };
 
 export const GenerateCompetitorAssignmentsForStaff: StepDefinition = {
@@ -286,7 +287,6 @@ export const GenerateJudgeAssignmentsForCompetitors: StepDefinition = {
       options: {
         mode: 'symmetric',
       },
-      globalScore: PNW_GLOBAL_SCORE,
       constraints: [
         {
           constraint: 'uniqueAssignment',

--- a/src/lib/recipes/types.ts
+++ b/src/lib/recipes/types.ts
@@ -9,7 +9,7 @@ export interface ClusterDefinition {
   base: string;
   filters: ClusterFilter[];
   sort?: {
-    by: 'speed';
+    by: 'speed' | 'mostConstrained';
     direction: 'asc' | 'desc';
   }
 }

--- a/src/lib/recipes/types.ts
+++ b/src/lib/recipes/types.ts
@@ -42,6 +42,7 @@ export interface AssignmentStep {
     globalScore?: {
       maxPasses?: number;
       maxEvaluations?: number;
+      maxClusterSize?: number;
     };
   };
 }

--- a/src/lib/recipes/types.ts
+++ b/src/lib/recipes/types.ts
@@ -39,6 +39,9 @@ export interface AssignmentStep {
     activities: ActivitiesDefinition;
     constraints: ConstraintProps[];
     options?: any;
+    globalScore?: {
+      maxPasses?: number;
+    };
   };
 }
 

--- a/src/lib/recipes/types.ts
+++ b/src/lib/recipes/types.ts
@@ -47,6 +47,7 @@ export interface GroupStep {
   type: 'groups';
   props: {
     count: number;
+    condition?: 'missingGroupsInFinalRound';
   };
 }
 

--- a/src/lib/recipes/types.ts
+++ b/src/lib/recipes/types.ts
@@ -41,6 +41,7 @@ export interface AssignmentStep {
     options?: any;
     globalScore?: {
       maxPasses?: number;
+      maxEvaluations?: number;
     };
   };
 }

--- a/src/pages/Competition/BulkGeneration/BulkRoundGroupCountsDialog.tsx
+++ b/src/pages/Competition/BulkGeneration/BulkRoundGroupCountsDialog.tsx
@@ -1,0 +1,46 @@
+import ConfigureGroupCountsDialog from '../../../dialogs/ConfigureGroupCountsDialog';
+import { findAllRoundActivities } from '../../../lib/wcif/activities';
+import type { Competition } from '@wca/helpers';
+import { useMemo } from 'react';
+
+interface BulkRoundGroupCountsDialogProps {
+  wcif: Competition | null;
+  roundId: string | null;
+  onClose: () => void;
+}
+
+export const BulkRoundGroupCountsDialog = ({
+  wcif,
+  roundId,
+  onClose,
+}: BulkRoundGroupCountsDialogProps) => {
+  const round = useMemo(
+    () =>
+      wcif && roundId
+        ? wcif.events.flatMap((event) => event.rounds).find((candidate) => candidate.id === roundId)
+        : undefined,
+    [roundId, wcif]
+  );
+
+  const roundActivities = useMemo(
+    () =>
+      wcif && roundId
+        ? findAllRoundActivities(wcif).filter((activity) => activity.activityCode === roundId)
+        : [],
+    [roundId, wcif]
+  );
+
+  if (!wcif || !roundId || !round) {
+    return null;
+  }
+
+  return (
+    <ConfigureGroupCountsDialog
+      open
+      onClose={onClose}
+      activityCode={roundId}
+      round={round}
+      roundActivities={roundActivities}
+    />
+  );
+};

--- a/src/pages/Competition/BulkGeneration/BulkRoundPreviewDialog.tsx
+++ b/src/pages/Competition/BulkGeneration/BulkRoundPreviewDialog.tsx
@@ -1,0 +1,51 @@
+import ConfigureAssignmentsDialog from '../../../dialogs/ConfigureAssignmentsDialog/ConfigureAssignmentsDialog';
+import { allChildActivities, findAllRoundActivities } from '../../../lib/wcif/activities';
+import type { Competition } from '@wca/helpers';
+import { useMemo } from 'react';
+
+interface BulkRoundPreviewDialogProps {
+  wcif: Competition | null;
+  roundId: string | null;
+  onClose: () => void;
+}
+
+export const BulkRoundPreviewDialog = ({
+  wcif,
+  roundId,
+  onClose,
+}: BulkRoundPreviewDialogProps) => {
+  const round = useMemo(
+    () =>
+      wcif && roundId
+        ? wcif.events.flatMap((event) => event.rounds).find((candidate) => candidate.id === roundId)
+        : undefined,
+    [roundId, wcif]
+  );
+
+  const groups = useMemo(
+    () =>
+      wcif && roundId
+        ? findAllRoundActivities(wcif)
+            .filter((activity) => activity.activityCode === roundId)
+            .flatMap((activity) => allChildActivities(activity))
+        : [],
+    [roundId, wcif]
+  );
+
+  if (!wcif || !roundId || !round) {
+    return null;
+  }
+
+  return (
+    <ConfigureAssignmentsDialog
+      open
+      onClose={onClose}
+      round={round}
+      activityCode={roundId}
+      groups={groups}
+      isDistributedAttemptRoundLevel={false}
+      distributedAttemptGroups={[]}
+      defaultShowAllCompetitors
+    />
+  );
+};

--- a/src/pages/Competition/BulkGeneration/BulkRoundTable.tsx
+++ b/src/pages/Competition/BulkGeneration/BulkRoundTable.tsx
@@ -17,6 +17,7 @@ import {
 interface BulkRoundTableProps {
   rows: BulkRoundRow[];
   selectedRoundIds: Set<string>;
+  disabled?: boolean;
   onToggleRound: (roundId: string) => void;
   onMoveRound: (roundId: string, direction: -1 | 1) => void;
 }
@@ -24,6 +25,7 @@ interface BulkRoundTableProps {
 export const BulkRoundTable = ({
   rows,
   selectedRoundIds,
+  disabled = false,
   onToggleRound,
   onMoveRound,
 }: BulkRoundTableProps) => (
@@ -47,7 +49,7 @@ export const BulkRoundTable = ({
             <TableCell padding="checkbox">
               <Checkbox
                 checked={selectedRoundIds.has(row.roundId)}
-                disabled={!row.selectable}
+                disabled={disabled || !row.selectable}
                 onChange={() => onToggleRound(row.roundId)}
                 slotProps={{ input: { 'aria-label': `Select ${row.roundId}` } }}
               />
@@ -59,7 +61,7 @@ export const BulkRoundTable = ({
                     <IconButton
                       size="small"
                       aria-label={`Move ${row.roundId} up`}
-                      disabled={index === 0}
+                      disabled={disabled || index === 0}
                       onClick={() => onMoveRound(row.roundId, -1)}>
                       <ArrowUpwardIcon fontSize="inherit" />
                     </IconButton>
@@ -70,7 +72,7 @@ export const BulkRoundTable = ({
                     <IconButton
                       size="small"
                       aria-label={`Move ${row.roundId} down`}
-                      disabled={index === rows.length - 1}
+                      disabled={disabled || index === rows.length - 1}
                       onClick={() => onMoveRound(row.roundId, 1)}>
                       <ArrowDownwardIcon fontSize="inherit" />
                     </IconButton>

--- a/src/pages/Competition/BulkGeneration/BulkRoundTable.tsx
+++ b/src/pages/Competition/BulkGeneration/BulkRoundTable.tsx
@@ -1,0 +1,94 @@
+import type { BulkRoundRow } from './bulkRoundRows';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import {
+  Checkbox,
+  IconButton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+} from '@mui/material';
+
+interface BulkRoundTableProps {
+  rows: BulkRoundRow[];
+  selectedRoundIds: Set<string>;
+  onToggleRound: (roundId: string) => void;
+  onMoveRound: (roundId: string, direction: -1 | 1) => void;
+}
+
+export const BulkRoundTable = ({
+  rows,
+  selectedRoundIds,
+  onToggleRound,
+  onMoveRound,
+}: BulkRoundTableProps) => (
+  <TableContainer>
+    <Table size="small" aria-label="bulk generation rounds">
+      <TableHead>
+        <TableRow>
+          <TableCell padding="checkbox">Generate</TableCell>
+          <TableCell>Order</TableCell>
+          <TableCell>Event/Round</TableCell>
+          <TableCell>Scheduled</TableCell>
+          <TableCell align="right">Size</TableCell>
+          <TableCell align="right">Groups</TableCell>
+          <TableCell align="right">Competitors</TableCell>
+          <TableCell align="right">Staff</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map((row, index) => (
+          <TableRow key={row.roundId} selected={selectedRoundIds.has(row.roundId)}>
+            <TableCell padding="checkbox">
+              <Checkbox
+                checked={selectedRoundIds.has(row.roundId)}
+                disabled={!row.selectable}
+                onChange={() => onToggleRound(row.roundId)}
+                slotProps={{ input: { 'aria-label': `Select ${row.roundId}` } }}
+              />
+            </TableCell>
+            <TableCell>
+              <Stack direction="row" spacing={0.5}>
+                <Tooltip title="Move up">
+                  <span>
+                    <IconButton
+                      size="small"
+                      aria-label={`Move ${row.roundId} up`}
+                      disabled={index === 0}
+                      onClick={() => onMoveRound(row.roundId, -1)}>
+                      <ArrowUpwardIcon fontSize="inherit" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+                <Tooltip title="Move down">
+                  <span>
+                    <IconButton
+                      size="small"
+                      aria-label={`Move ${row.roundId} down`}
+                      disabled={index === rows.length - 1}
+                      onClick={() => onMoveRound(row.roundId, 1)}>
+                      <ArrowDownwardIcon fontSize="inherit" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Stack>
+            </TableCell>
+            <TableCell>{row.label}</TableCell>
+            <TableCell>{row.scheduledTime}</TableCell>
+            <TableCell align="right">{row.roundSize}</TableCell>
+            <TableCell align="right">{row.existingGroupCount}</TableCell>
+            <TableCell align="right">
+              {row.competitorAssignmentCount} / {row.roundSize}
+            </TableCell>
+            <TableCell align="right">{row.staffAssignmentCount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </TableContainer>
+);

--- a/src/pages/Competition/BulkGeneration/BulkRoundTable.tsx
+++ b/src/pages/Competition/BulkGeneration/BulkRoundTable.tsx
@@ -2,6 +2,7 @@ import type { BulkRoundRow } from './bulkRoundRows';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import {
+  Button,
   Checkbox,
   IconButton,
   Stack,
@@ -20,6 +21,8 @@ interface BulkRoundTableProps {
   disabled?: boolean;
   onToggleRound: (roundId: string) => void;
   onMoveRound: (roundId: string, direction: -1 | 1) => void;
+  onPreviewRound: (roundId: string) => void;
+  onConfigureGroups: (roundId: string) => void;
 }
 
 export const BulkRoundTable = ({
@@ -28,6 +31,8 @@ export const BulkRoundTable = ({
   disabled = false,
   onToggleRound,
   onMoveRound,
+  onPreviewRound,
+  onConfigureGroups,
 }: BulkRoundTableProps) => (
   <TableContainer>
     <Table size="small" aria-label="bulk generation rounds">
@@ -41,6 +46,7 @@ export const BulkRoundTable = ({
           <TableCell align="right">Groups</TableCell>
           <TableCell align="right">Competitors</TableCell>
           <TableCell align="right">Staff</TableCell>
+          <TableCell align="right">Actions</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -88,6 +94,19 @@ export const BulkRoundTable = ({
               {row.competitorAssignmentCount} / {row.roundSize}
             </TableCell>
             <TableCell align="right">{row.staffAssignmentCount}</TableCell>
+            <TableCell align="right">
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={disabled}
+                onClick={() =>
+                  row.existingGroupCount > 0
+                    ? onPreviewRound(row.roundId)
+                    : onConfigureGroups(row.roundId)
+                }>
+                {row.existingGroupCount > 0 ? 'Preview' : 'Configure'}
+              </Button>
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/src/pages/Competition/BulkGeneration/bulkGeneration.worker.ts
+++ b/src/pages/Competition/BulkGeneration/bulkGeneration.worker.ts
@@ -1,0 +1,37 @@
+import { runBulkRecipesOnWcif } from '../../../lib/recipes/runRecipeOnWcif';
+import type {
+  BulkGenerationWorkerRequest,
+  BulkGenerationWorkerResponse,
+} from './bulkGenerationWorkerTypes';
+
+const workerScope = self as unknown as {
+  postMessage: (message: BulkGenerationWorkerResponse) => void;
+  addEventListener: (
+    type: 'message',
+    listener: (event: MessageEvent<BulkGenerationWorkerRequest>) => void
+  ) => void;
+};
+
+workerScope.addEventListener('message', (event) => {
+  const message = event.data;
+  if (message.type !== 'runBulkGeneration') {
+    return;
+  }
+
+  try {
+    const wcif = runBulkRecipesOnWcif(message.wcif, {
+      recipeId: message.recipeId,
+      roundIds: message.roundIds,
+      onProgress: (progress) => {
+        workerScope.postMessage({ type: 'progress', ...progress });
+      },
+    });
+
+    workerScope.postMessage({ type: 'complete', wcif });
+  } catch (error) {
+    workerScope.postMessage({
+      type: 'error',
+      message: error instanceof Error ? error.message : 'Bulk generation failed',
+    });
+  }
+});

--- a/src/pages/Competition/BulkGeneration/bulkGenerationWorkerTypes.ts
+++ b/src/pages/Competition/BulkGeneration/bulkGenerationWorkerTypes.ts
@@ -1,0 +1,31 @@
+import type { Competition } from '@wca/helpers';
+
+export type BulkGenerationProgressPhase = 'generating' | 'fixing' | 'staff';
+
+export interface BulkGenerationWorkerRequest {
+  type: 'runBulkGeneration';
+  wcif: Competition;
+  recipeId: string;
+  roundIds: string[];
+}
+
+export interface BulkGenerationWorkerProgress {
+  type: 'progress';
+  phase: BulkGenerationProgressPhase;
+  roundId?: string;
+}
+
+export interface BulkGenerationWorkerComplete {
+  type: 'complete';
+  wcif: Competition;
+}
+
+export interface BulkGenerationWorkerError {
+  type: 'error';
+  message: string;
+}
+
+export type BulkGenerationWorkerResponse =
+  | BulkGenerationWorkerProgress
+  | BulkGenerationWorkerComplete
+  | BulkGenerationWorkerError;

--- a/src/pages/Competition/BulkGeneration/bulkRoundRows.test.ts
+++ b/src/pages/Competition/BulkGeneration/bulkRoundRows.test.ts
@@ -1,0 +1,119 @@
+import {
+  buildBulkRoundRows,
+  defaultSelectedRoundIds,
+  mergeRoundOrder,
+  scheduleOrderedRoundIds,
+} from './bulkRoundRows';
+import {
+  buildActivity,
+  buildEvent,
+  buildPerson,
+  buildRound,
+  buildWcifWithEvents,
+} from '../../../store/reducers/_tests_/helpers';
+import type { AssignmentCode, Competition, EventId } from '@wca/helpers';
+import { describe, expect, it } from 'vitest';
+
+const assignment = (activityId: number, assignmentCode: AssignmentCode) => ({
+  activityId,
+  assignmentCode,
+  stationNumber: null,
+});
+
+const registration = (registrantId: number, eventIds: EventId[]) => ({
+  status: 'accepted' as const,
+  eventIds,
+  isCompeting: true,
+  comments: undefined,
+  wcaRegistrationId: registrantId,
+});
+
+const buildCompetition = (): Competition => {
+  const round333 = buildActivity({
+    id: 1,
+    activityCode: '333-r1',
+    startTime: '2024-01-01T11:00:00Z',
+    endTime: '2024-01-01T11:30:00Z',
+    childActivities: [
+      buildActivity({ id: 101, activityCode: '333-r1-g1' }),
+      buildActivity({ id: 102, activityCode: '333-r1-g2' }),
+    ],
+  });
+  const round333Second = buildActivity({
+    id: 2,
+    activityCode: '333-r2',
+    startTime: '2024-01-01T10:00:00Z',
+    endTime: '2024-01-01T10:30:00Z',
+    childActivities: [buildActivity({ id: 201, activityCode: '333-r2-g1' })],
+  });
+  const distributedRound = buildActivity({
+    id: 3,
+    activityCode: '333fm-r1',
+    childActivities: [],
+  });
+
+  return buildWcifWithEvents(
+    [round333, round333Second, distributedRound],
+    [
+      buildEvent({
+        id: '333',
+        rounds: [
+          buildRound({ id: '333-r1' }),
+          buildRound({
+            id: '333-r2',
+            results: [{ personId: 1, ranking: 1, attempts: [], best: 0, average: 0 }],
+          }),
+        ],
+      }),
+      buildEvent({
+        id: '333fm' as EventId,
+        rounds: [buildRound({ id: '333fm-r1' })],
+      }),
+    ],
+    [
+      buildPerson({
+        registrantId: 1,
+        registration: registration(1, ['333' as EventId]),
+        assignments: [assignment(101, 'competitor'), assignment(102, 'staff-judge')],
+      }),
+      buildPerson({
+        registrantId: 2,
+        registration: registration(2, ['333' as EventId]),
+        assignments: [assignment(201, 'competitor')],
+      }),
+    ]
+  );
+};
+
+describe('bulkRoundRows', () => {
+  it('builds normal non-distributed round review rows', () => {
+    const rows = buildBulkRoundRows(buildCompetition());
+
+    expect(rows.map((row) => row.roundId)).toEqual(['333-r1', '333-r2']);
+    expect(rows[0]).toMatchObject({
+      label: '333 Round 1',
+      roundSize: 2,
+      existingGroupCount: 2,
+      competitorAssignmentCount: 1,
+      staffAssignmentCount: 1,
+      warnings: [],
+      selectable: true,
+    });
+    expect(rows[1]).toMatchObject({
+      roundSize: 1,
+      selectable: true,
+    });
+    expect(defaultSelectedRoundIds(rows)).toEqual(new Set(['333-r1']));
+  });
+
+  it('orders rows by schedule and merges persisted order with current rounds', () => {
+    const rows = buildBulkRoundRows(buildCompetition());
+
+    expect(scheduleOrderedRoundIds(rows)).toEqual(['333-r2', '333-r1']);
+    expect(mergeRoundOrder(['333-r2', '333-r1', '222-r1'], ['333-r1', 'stale-r1'])).toEqual([
+      '333-r1',
+      '333-r2',
+      '222-r1',
+    ]);
+  });
+});

--- a/src/pages/Competition/BulkGeneration/bulkRoundRows.test.ts
+++ b/src/pages/Competition/BulkGeneration/bulkRoundRows.test.ts
@@ -91,7 +91,7 @@ describe('bulkRoundRows', () => {
 
     expect(rows.map((row) => row.roundId)).toEqual(['333-r1', '333-r2']);
     expect(rows[0]).toMatchObject({
-      label: '333 Round 1',
+      label: '3x3 Round 1',
       roundSize: 2,
       existingGroupCount: 2,
       competitorAssignmentCount: 1,
@@ -104,6 +104,27 @@ describe('bulkRoundRows', () => {
       selectable: true,
     });
     expect(defaultSelectedRoundIds(rows)).toEqual(new Set(['333-r1']));
+  });
+
+  it('requires groups before a round is selectable', () => {
+    const competition = buildCompetition();
+    const roundActivity = competition.schedule.venues[0].rooms[0].activities.find(
+      (activity) => activity.activityCode === '333-r1'
+    );
+    if (!roundActivity) {
+      throw new Error('Expected 333-r1 activity');
+    }
+    roundActivity.childActivities = [];
+
+    const rows = buildBulkRoundRows(competition);
+
+    expect(rows[0]).toMatchObject({
+      roundId: '333-r1',
+      roundSize: 2,
+      existingGroupCount: 0,
+      selectable: false,
+    });
+    expect(defaultSelectedRoundIds(rows)).toEqual(new Set());
   });
 
   it('orders rows by schedule and merges persisted order with current rounds', () => {

--- a/src/pages/Competition/BulkGeneration/bulkRoundRows.ts
+++ b/src/pages/Competition/BulkGeneration/bulkRoundRows.ts
@@ -1,0 +1,162 @@
+import {
+  activityCodeIsChild,
+  hasDistributedAttempts,
+  parseActivityCode,
+} from '../../../lib/domain/activities';
+import { personsShouldBeInRound } from '../../../lib/domain/persons';
+import { findAllActivities } from '../../../lib/wcif/activities';
+import { formatDateTimeRange } from '../../../lib/utils/time';
+import type { Activity, Assignment, Competition, Event, Round } from '@wca/helpers';
+
+export interface BulkRoundRow {
+  roundId: string;
+  eventId: string;
+  roundNumber: number;
+  label: string;
+  scheduledTime: string;
+  scheduleStartTime: string | null;
+  scheduleEndTime: string | null;
+  roundSize: number;
+  existingGroupCount: number;
+  competitorAssignmentCount: number;
+  staffAssignmentCount: number;
+  warnings: string[];
+  selectable: boolean;
+}
+
+const eventRoundLabel = (event: Event, round: Round) => {
+  const { roundNumber } = parseActivityCode(round.id);
+  return `${event.id.toUpperCase()} Round ${roundNumber ?? '?'}`;
+};
+
+const scheduledTimeForActivities = (activities: Activity[]) => {
+  const { startTime, endTime } = scheduleBoundsForActivities(activities);
+  return startTime && endTime ? formatDateTimeRange(startTime, endTime) : 'Unscheduled';
+};
+
+const scheduleBoundsForActivities = (activities: Activity[]) => {
+  const activitiesWithTimes = activities.filter((activity) => activity.startTime && activity.endTime);
+  if (activitiesWithTimes.length === 0) {
+    return { startTime: null, endTime: null };
+  }
+
+  const startTime = activitiesWithTimes
+    .map((activity) => activity.startTime)
+    .sort((timeA, timeB) => timeA.localeCompare(timeB))[0];
+  const endTime = activitiesWithTimes
+    .map((activity) => activity.endTime)
+    .sort((timeA, timeB) => timeB.localeCompare(timeA))[0];
+
+  return { startTime, endTime };
+};
+
+const assignmentIsInRound = (
+  assignment: Assignment,
+  roundId: string,
+  activityById: Map<number, Activity>
+) => {
+  const activity = activityById.get(assignment.activityId);
+  return activity ? activityCodeIsChild(roundId, activity.activityCode) : false;
+};
+
+const countAssignments = (
+  wcif: Competition,
+  roundId: string,
+  activityById: Map<number, Activity>,
+  predicate: (assignment: Assignment) => boolean
+) =>
+  wcif.persons.reduce(
+    (count, person) =>
+      count +
+      (person.assignments ?? []).filter(
+        (assignment) => assignmentIsInRound(assignment, roundId, activityById) && predicate(assignment)
+      ).length,
+    0
+  );
+
+export const buildBulkRoundRows = (wcif: Competition): BulkRoundRow[] => {
+  const allActivities = findAllActivities(wcif);
+  const activityById = new Map(allActivities.map((activity) => [activity.id, activity]));
+
+  return wcif.events.flatMap((event) =>
+    event.rounds
+      .filter((round) => !hasDistributedAttempts(round.id))
+      .map((round) => {
+        const { roundNumber } = parseActivityCode(round.id);
+        const roundActivities = allActivities.filter((activity) => activity.activityCode === round.id);
+        const scheduleBounds = scheduleBoundsForActivities(roundActivities);
+        const existingGroupCount = roundActivities.reduce(
+          (count, activity) => count + (activity.childActivities ?? []).length,
+          0
+        );
+        const roundSize = personsShouldBeInRound(round)(wcif.persons).length;
+        const competitorAssignmentCount = countAssignments(
+          wcif,
+          round.id,
+          activityById,
+          (assignment) => assignment.assignmentCode === 'competitor'
+        );
+        const staffAssignmentCount = countAssignments(
+          wcif,
+          round.id,
+          activityById,
+          (assignment) => assignment.assignmentCode !== 'competitor'
+        );
+        const warnings = [
+          roundSize === 0 ? 'No competitors' : null,
+          roundActivities.length === 0 ? 'No scheduled activity' : null,
+          existingGroupCount === 0 ? 'No groups' : null,
+        ].filter((warning): warning is string => Boolean(warning));
+
+        return {
+          roundId: round.id,
+          eventId: event.id,
+          roundNumber: roundNumber ?? 0,
+          label: eventRoundLabel(event, round),
+          scheduledTime: scheduledTimeForActivities(roundActivities),
+          scheduleStartTime: scheduleBounds.startTime,
+          scheduleEndTime: scheduleBounds.endTime,
+          roundSize,
+          existingGroupCount,
+          competitorAssignmentCount,
+          staffAssignmentCount,
+          warnings,
+          selectable: roundSize > 0,
+        };
+      })
+  );
+};
+
+export const defaultSelectedRoundIds = (rows: BulkRoundRow[]) =>
+  new Set(rows.filter((row) => row.roundNumber === 1 && row.selectable).map((row) => row.roundId));
+
+export const scheduleOrderedRoundIds = (rows: BulkRoundRow[]) =>
+  [...rows]
+    .sort((rowA, rowB) => {
+      if (rowA.scheduleStartTime && rowB.scheduleStartTime) {
+        return (
+          rowA.scheduleStartTime.localeCompare(rowB.scheduleStartTime) ||
+          (rowA.scheduleEndTime ?? '').localeCompare(rowB.scheduleEndTime ?? '') ||
+          rowA.roundId.localeCompare(rowB.roundId)
+        );
+      }
+
+      if (rowA.scheduleStartTime) {
+        return -1;
+      }
+
+      if (rowB.scheduleStartTime) {
+        return 1;
+      }
+
+      return rowA.roundId.localeCompare(rowB.roundId);
+    })
+    .map((row) => row.roundId);
+
+export const mergeRoundOrder = (roundIds: string[], persistedRoundIds: string[]) => {
+  const currentRoundIds = new Set(roundIds);
+  const persistedCurrentRoundIds = persistedRoundIds.filter((roundId) => currentRoundIds.has(roundId));
+  const missingRoundIds = roundIds.filter((roundId) => !persistedCurrentRoundIds.includes(roundId));
+
+  return [...persistedCurrentRoundIds, ...missingRoundIds];
+};

--- a/src/pages/Competition/BulkGeneration/bulkRoundRows.ts
+++ b/src/pages/Competition/BulkGeneration/bulkRoundRows.ts
@@ -3,6 +3,7 @@ import {
   hasDistributedAttempts,
   parseActivityCode,
 } from '../../../lib/domain/activities';
+import { shortEventNameById } from '../../../lib/domain/events';
 import { personsShouldBeInRound } from '../../../lib/domain/persons';
 import { findAllActivities } from '../../../lib/wcif/activities';
 import { formatDateTimeRange } from '../../../lib/utils/time';
@@ -26,7 +27,7 @@ export interface BulkRoundRow {
 
 const eventRoundLabel = (event: Event, round: Round) => {
   const { roundNumber } = parseActivityCode(round.id);
-  return `${event.id.toUpperCase()} Round ${roundNumber ?? '?'}`;
+  return `${shortEventNameById(event.id)} Round ${roundNumber ?? '?'}`;
 };
 
 const scheduledTimeForActivities = (activities: Activity[]) => {
@@ -121,7 +122,7 @@ export const buildBulkRoundRows = (wcif: Competition): BulkRoundRow[] => {
           competitorAssignmentCount,
           staffAssignmentCount,
           warnings,
-          selectable: roundSize > 0,
+          selectable: roundSize > 0 && existingGroupCount > 0,
         };
       })
   );

--- a/src/pages/Competition/BulkGeneration/index.test.tsx
+++ b/src/pages/Competition/BulkGeneration/index.test.tsx
@@ -10,8 +10,12 @@ import {
 } from '../../../store/reducers/_tests_/helpers';
 import type { AppState } from '../../../store/initialState';
 import { ActionType } from '../../../store/actions';
+import type {
+  BulkGenerationWorkerRequest,
+  BulkGenerationWorkerResponse,
+} from './bulkGenerationWorkerTypes';
 import type { EventId } from '@wca/helpers';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -20,6 +24,26 @@ const dispatchMock = vi.fn();
 const useAppSelectorMock = vi.fn();
 const getLocalStorageMock = vi.fn();
 const setLocalStorageMock = vi.fn();
+const workerInstances: MockWorker[] = [];
+
+class MockWorker {
+  onmessage: ((event: MessageEvent<BulkGenerationWorkerResponse>) => void) | null = null;
+  onerror: (() => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
+
+  constructor() {
+    workerInstances.push(this);
+  }
+
+  get request() {
+    return this.postMessage.mock.calls[0]?.[0] as BulkGenerationWorkerRequest | undefined;
+  }
+
+  emit(message: BulkGenerationWorkerResponse) {
+    this.onmessage?.({ data: message } as MessageEvent<BulkGenerationWorkerResponse>);
+  }
+}
 
 vi.mock('../../../store', () => ({
   useAppDispatch: () => dispatchMock,
@@ -121,6 +145,8 @@ const renderPage = () =>
 describe('BulkGenerationPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    workerInstances.length = 0;
+    vi.stubGlobal('Worker', MockWorker);
     getLocalStorageMock.mockReturnValue(null);
     const state = { wcif: buildCompetition() } as AppState;
     useAppSelectorMock.mockImplementation((selector: (state: AppState) => unknown) =>
@@ -167,11 +193,23 @@ describe('BulkGenerationPage', () => {
     await user.click(screen.getByLabelText('Select 333-r2'));
     await user.click(screen.getByLabelText('Move 333-r2 up'));
     await user.click(screen.getByRole('button', { name: 'Generate' }));
+    const worker = workerInstances[0];
 
-    expect(dispatchMock).toHaveBeenCalledWith({
-      type: ActionType.RUN_RECIPES,
+    expect(worker.request).toMatchObject({
+      type: 'runBulkGeneration',
       recipeId: 'pnw',
       roundIds: ['333-r2', '222-r1', '333-r1'],
+    });
+    act(() => {
+      worker.emit({ type: 'complete', wcif: buildCompetition() });
+    });
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: ActionType.PARTIAL_UPDATE_WCIF,
+      wcif: expect.objectContaining({
+        events: expect.any(Array),
+        persons: expect.any(Array),
+        schedule: expect.any(Object),
+      }),
     });
     expect(setLocalStorageMock).toHaveBeenLastCalledWith(
       'bulk-generation.round-order.test-comp',
@@ -184,9 +222,10 @@ describe('BulkGenerationPage', () => {
     renderPage();
 
     await user.click(screen.getByRole('button', { name: 'Generate' }));
+    const worker = workerInstances[0];
 
-    expect(dispatchMock).toHaveBeenCalledWith({
-      type: ActionType.RUN_RECIPES,
+    expect(worker.request).toMatchObject({
+      type: 'runBulkGeneration',
       recipeId: 'pnw',
       roundIds: ['222-r1', '333-r1'],
     });
@@ -198,9 +237,10 @@ describe('BulkGenerationPage', () => {
     renderPage();
 
     await user.click(screen.getByRole('button', { name: 'Generate' }));
+    const worker = workerInstances[0];
 
-    expect(dispatchMock).toHaveBeenCalledWith({
-      type: ActionType.RUN_RECIPES,
+    expect(worker.request).toMatchObject({
+      type: 'runBulkGeneration',
       recipeId: 'pnw',
       roundIds: ['333-r1', '222-r1'],
     });
@@ -217,15 +257,56 @@ describe('BulkGenerationPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Reset to Schedule Order' }));
     await user.click(screen.getByRole('button', { name: 'Generate' }));
+    const worker = workerInstances[0];
 
     expect(setLocalStorageMock).toHaveBeenLastCalledWith(
       'bulk-generation.round-order.test-comp',
       JSON.stringify(['222-r1', '333-r2', '333-r1', '222-r2'])
     );
-    expect(dispatchMock).toHaveBeenCalledWith({
-      type: ActionType.RUN_RECIPES,
+    expect(worker.request).toMatchObject({
+      type: 'runBulkGeneration',
       recipeId: 'pnw',
       roundIds: ['222-r1', '333-r1'],
     });
+  });
+
+  it('shows worker progress and disables controls while generation is running', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+    const worker = workerInstances[0];
+
+    expect(screen.getByText('Starting bulk generation')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeDisabled();
+    expect(screen.getByLabelText('Select 333-r1')).toBeDisabled();
+
+    act(() => {
+      worker.emit({ type: 'progress', phase: 'generating', roundId: '222-r1' });
+    });
+    expect(screen.getByText('Generating for 222 Round 1')).toBeInTheDocument();
+
+    act(() => {
+      worker.emit({ type: 'progress', phase: 'fixing' });
+    });
+    expect(screen.getByText('Fixing group assignments')).toBeInTheDocument();
+
+    act(() => {
+      worker.emit({ type: 'progress', phase: 'staff', roundId: '333-r1' });
+    });
+    expect(screen.getByText('Generating staff assignments for 333 Round 1')).toBeInTheDocument();
+  });
+
+  it('shows worker errors and leaves WCIF unchanged', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+    act(() => {
+      workerInstances[0].emit({ type: 'error', message: 'Recipe failed' });
+    });
+
+    expect(screen.getByText('Recipe failed')).toBeInTheDocument();
+    expect(dispatchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/Competition/BulkGeneration/index.test.tsx
+++ b/src/pages/Competition/BulkGeneration/index.test.tsx
@@ -15,7 +15,7 @@ import type {
   BulkGenerationWorkerResponse,
 } from './bulkGenerationWorkerTypes';
 import type { EventId } from '@wca/helpers';
-import { act, screen } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -55,6 +55,33 @@ vi.mock('../../../lib/api', () => ({
   setLocalStorage: (key: string, value: string) => setLocalStorageMock(key, value),
 }));
 
+vi.mock('../../../dialogs/ConfigureAssignmentsDialog/ConfigureAssignmentsDialog', () => ({
+  default: ({
+    activityCode,
+    defaultShowAllCompetitors,
+    onClose,
+  }: {
+    activityCode: string;
+    defaultShowAllCompetitors?: boolean;
+    onClose: () => void;
+  }) => (
+    <div role="dialog" aria-label={`Preview ${activityCode}`}>
+      <span>Previewing {activityCode}</span>
+      <span>Show all: {defaultShowAllCompetitors ? 'yes' : 'no'}</span>
+      <button onClick={onClose}>Close Preview</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../../dialogs/ConfigureGroupCountsDialog', () => ({
+  default: ({ activityCode, onClose }: { activityCode: string; onClose: () => void }) => (
+    <div role="dialog" aria-label={`Configure groups ${activityCode}`}>
+      <span>Configuring groups for {activityCode}</span>
+      <button onClick={onClose}>Close Configure Groups</button>
+    </div>
+  ),
+}));
+
 const registration = (registrantId: number, eventIds: EventId[]) => ({
   status: 'accepted' as const,
   eventIds,
@@ -92,7 +119,7 @@ const buildCompetition = () =>
         activityCode: '222-r2',
         startTime: '2024-01-01T12:00:00Z',
         endTime: '2024-01-01T12:30:00Z',
-        childActivities: [buildActivity({ id: 401, activityCode: '222-r2-g1' })],
+        childActivities: [],
       }),
       buildActivity({
         id: 5,
@@ -160,25 +187,26 @@ describe('BulkGenerationPage', () => {
     expect(screen.getByRole('heading', { name: 'Bulk Generate' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Size' })).toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Assigned' })).not.toBeInTheDocument();
-    expect(screen.getByText('333 Round 1')).toBeInTheDocument();
-    expect(screen.getByText('333 Round 2')).toBeInTheDocument();
-    expect(screen.getByText('222 Round 1')).toBeInTheDocument();
-    expect(screen.getByText('222 Round 2')).toBeInTheDocument();
+    expect(screen.getByText('3x3 Round 1')).toBeInTheDocument();
+    expect(screen.getByText('3x3 Round 2')).toBeInTheDocument();
+    expect(screen.getByText('2x2 Round 1')).toBeInTheDocument();
+    expect(screen.getByText('2x2 Round 2')).toBeInTheDocument();
     expect(screen.queryByText('333FM Round 1')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Select 333-r1')).toBeChecked();
     expect(screen.getByLabelText('Select 222-r1')).toBeChecked();
     expect(screen.getByLabelText('Select 333-r2')).not.toBeChecked();
     expect(screen.getByLabelText('Select 333-r2')).not.toBeDisabled();
     expect(screen.getByLabelText('Select 222-r2')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Configure' })).toBeInTheDocument();
 
     const rowTexts = screen.getAllByRole('row').map((row) => row.textContent ?? '');
-    expect(rowTexts[1]).toContain('222 Round 1');
+    expect(rowTexts[1]).toContain('2x2 Round 1');
     expect(rowTexts[1]).toContain('0 / 2');
-    expect(rowTexts[2]).toContain('333 Round 2');
+    expect(rowTexts[2]).toContain('3x3 Round 2');
     expect(rowTexts[2]).toContain('0 / 1');
-    expect(rowTexts[3]).toContain('333 Round 1');
+    expect(rowTexts[3]).toContain('3x3 Round 1');
     expect(rowTexts[3]).toContain('0 / 2');
-    expect(rowTexts[4]).toContain('222 Round 2');
+    expect(rowTexts[4]).toContain('2x2 Round 2');
     expect(rowTexts[4]).toContain('0 / 0');
     expect(setLocalStorageMock).toHaveBeenCalledWith(
       'bulk-generation.round-order.test-comp',
@@ -280,11 +308,12 @@ describe('BulkGenerationPage', () => {
     expect(screen.getByText('Starting bulk generation')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Generate' })).toBeDisabled();
     expect(screen.getByLabelText('Select 333-r1')).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /Preview/ })[0]).toBeDisabled();
 
     act(() => {
       worker.emit({ type: 'progress', phase: 'generating', roundId: '222-r1' });
     });
-    expect(screen.getByText('Generating for 222 Round 1')).toBeInTheDocument();
+    expect(screen.getByText('Generating for 2x2 Round 1')).toBeInTheDocument();
 
     act(() => {
       worker.emit({ type: 'progress', phase: 'fixing' });
@@ -294,7 +323,7 @@ describe('BulkGenerationPage', () => {
     act(() => {
       worker.emit({ type: 'progress', phase: 'staff', roundId: '333-r1' });
     });
-    expect(screen.getByText('Generating staff assignments for 333 Round 1')).toBeInTheDocument();
+    expect(screen.getByText('Generating staff assignments for 3x3 Round 1')).toBeInTheDocument();
   });
 
   it('shows worker errors and leaves WCIF unchanged', async () => {
@@ -308,5 +337,46 @@ describe('BulkGenerationPage', () => {
 
     expect(screen.getByText('Recipe failed')).toBeInTheDocument();
     expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it('opens assignment preview for a round', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const roundRow = screen
+      .getAllByRole('row')
+      .find((row) => row.textContent?.includes('3x3 Round 2'));
+    expect(roundRow).toBeDefined();
+
+    await user.click(within(roundRow as HTMLElement).getByRole('button', { name: /Preview/ }));
+
+    expect(screen.getByRole('dialog', { name: 'Preview 333-r2' })).toBeInTheDocument();
+    expect(screen.getByText('Show all: yes')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close Preview' }));
+
+    expect(screen.queryByRole('dialog', { name: 'Preview 333-r2' })).not.toBeInTheDocument();
+  });
+
+  it('opens group count configuration for rounds without groups', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const roundRow = screen
+      .getAllByRole('row')
+      .find((row) => row.textContent?.includes('2x2 Round 2'));
+    expect(roundRow).toBeDefined();
+
+    await user.click(within(roundRow as HTMLElement).getByRole('button', { name: 'Configure' }));
+
+    expect(
+      screen.getByRole('dialog', { name: 'Configure groups 222-r2' })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close Configure Groups' }));
+
+    expect(
+      screen.queryByRole('dialog', { name: 'Configure groups 222-r2' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Competition/BulkGeneration/index.test.tsx
+++ b/src/pages/Competition/BulkGeneration/index.test.tsx
@@ -1,0 +1,231 @@
+import BulkGenerationPage from '.';
+import BreadcrumbsProvider from '../../../providers/BreadcrumbsProvider';
+import { renderWithProviders } from '../../../test-utils';
+import {
+  buildActivity,
+  buildEvent,
+  buildPerson,
+  buildRound,
+  buildWcifWithEvents,
+} from '../../../store/reducers/_tests_/helpers';
+import type { AppState } from '../../../store/initialState';
+import { ActionType } from '../../../store/actions';
+import type { EventId } from '@wca/helpers';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dispatchMock = vi.fn();
+const useAppSelectorMock = vi.fn();
+const getLocalStorageMock = vi.fn();
+const setLocalStorageMock = vi.fn();
+
+vi.mock('../../../store', () => ({
+  useAppDispatch: () => dispatchMock,
+  useAppSelector: (selector: (state: AppState) => unknown) => useAppSelectorMock(selector),
+}));
+
+vi.mock('../../../lib/api', () => ({
+  getLocalStorage: (key: string) => getLocalStorageMock(key),
+  setLocalStorage: (key: string, value: string) => setLocalStorageMock(key, value),
+}));
+
+const registration = (registrantId: number, eventIds: EventId[]) => ({
+  status: 'accepted' as const,
+  eventIds,
+  isCompeting: true,
+  comments: undefined,
+  wcaRegistrationId: registrantId,
+});
+
+const buildCompetition = () =>
+  buildWcifWithEvents(
+    [
+      buildActivity({
+        id: 1,
+        activityCode: '333-r1',
+        startTime: '2024-01-01T11:00:00Z',
+        endTime: '2024-01-01T11:30:00Z',
+        childActivities: [buildActivity({ id: 101, activityCode: '333-r1-g1' })],
+      }),
+      buildActivity({
+        id: 2,
+        activityCode: '333-r2',
+        startTime: '2024-01-01T10:00:00Z',
+        endTime: '2024-01-01T10:30:00Z',
+        childActivities: [buildActivity({ id: 201, activityCode: '333-r2-g1' })],
+      }),
+      buildActivity({
+        id: 3,
+        activityCode: '222-r1',
+        startTime: '2024-01-01T09:00:00Z',
+        endTime: '2024-01-01T09:30:00Z',
+        childActivities: [buildActivity({ id: 301, activityCode: '222-r1-g1' })],
+      }),
+      buildActivity({
+        id: 4,
+        activityCode: '222-r2',
+        startTime: '2024-01-01T12:00:00Z',
+        endTime: '2024-01-01T12:30:00Z',
+        childActivities: [buildActivity({ id: 401, activityCode: '222-r2-g1' })],
+      }),
+      buildActivity({
+        id: 5,
+        activityCode: '333fm-r1',
+        childActivities: [],
+      }),
+    ],
+    [
+      buildEvent({
+        id: '333',
+        rounds: [
+          buildRound({ id: '333-r1' }),
+          buildRound({
+            id: '333-r2',
+            results: [{ personId: 1, ranking: 1, attempts: [], best: 0, average: 0 }],
+          }),
+        ],
+      }),
+      buildEvent({
+        id: '222',
+        rounds: [buildRound({ id: '222-r1' }), buildRound({ id: '222-r2' })],
+      }),
+      buildEvent({
+        id: '333fm' as EventId,
+        rounds: [buildRound({ id: '333fm-r1' })],
+      }),
+    ],
+    [
+      buildPerson({
+        registrantId: 1,
+        registration: registration(1, ['333' as EventId, '222' as EventId]),
+      }),
+      buildPerson({
+        registrantId: 2,
+        registration: registration(2, ['333' as EventId, '222' as EventId]),
+      }),
+    ]
+  );
+
+const renderPage = () =>
+  renderWithProviders(
+    <BreadcrumbsProvider>
+      <Routes>
+        <Route path="/competitions/:competitionId/bulk-generation" element={<BulkGenerationPage />} />
+      </Routes>
+    </BreadcrumbsProvider>,
+    { route: '/competitions/test-comp/bulk-generation' }
+  );
+
+describe('BulkGenerationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLocalStorageMock.mockReturnValue(null);
+    const state = { wcif: buildCompetition() } as AppState;
+    useAppSelectorMock.mockImplementation((selector: (state: AppState) => unknown) =>
+      selector(state)
+    );
+  });
+
+  it('renders normal rounds with Round 1 selected by default and distributed attempts excluded', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Bulk Generate' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Size' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Assigned' })).not.toBeInTheDocument();
+    expect(screen.getByText('333 Round 1')).toBeInTheDocument();
+    expect(screen.getByText('333 Round 2')).toBeInTheDocument();
+    expect(screen.getByText('222 Round 1')).toBeInTheDocument();
+    expect(screen.getByText('222 Round 2')).toBeInTheDocument();
+    expect(screen.queryByText('333FM Round 1')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Select 333-r1')).toBeChecked();
+    expect(screen.getByLabelText('Select 222-r1')).toBeChecked();
+    expect(screen.getByLabelText('Select 333-r2')).not.toBeChecked();
+    expect(screen.getByLabelText('Select 333-r2')).not.toBeDisabled();
+    expect(screen.getByLabelText('Select 222-r2')).toBeDisabled();
+
+    const rowTexts = screen.getAllByRole('row').map((row) => row.textContent ?? '');
+    expect(rowTexts[1]).toContain('222 Round 1');
+    expect(rowTexts[1]).toContain('0 / 2');
+    expect(rowTexts[2]).toContain('333 Round 2');
+    expect(rowTexts[2]).toContain('0 / 1');
+    expect(rowTexts[3]).toContain('333 Round 1');
+    expect(rowTexts[3]).toContain('0 / 2');
+    expect(rowTexts[4]).toContain('222 Round 2');
+    expect(rowTexts[4]).toContain('0 / 0');
+    expect(setLocalStorageMock).toHaveBeenCalledWith(
+      'bulk-generation.round-order.test-comp',
+      JSON.stringify(['222-r1', '333-r2', '333-r1', '222-r2'])
+    );
+  });
+
+  it('dispatches selected rounds in displayed order after manual reordering', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByLabelText('Select 333-r2'));
+    await user.click(screen.getByLabelText('Move 333-r2 up'));
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: ActionType.RUN_RECIPES,
+      recipeId: 'pnw',
+      roundIds: ['333-r2', '222-r1', '333-r1'],
+    });
+    expect(setLocalStorageMock).toHaveBeenLastCalledWith(
+      'bulk-generation.round-order.test-comp',
+      JSON.stringify(['333-r2', '222-r1', '333-r1', '222-r2'])
+    );
+  });
+
+  it('does not dispatch later rounds with no competitors', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: ActionType.RUN_RECIPES,
+      recipeId: 'pnw',
+      roundIds: ['222-r1', '333-r1'],
+    });
+  });
+
+  it('uses persisted round order when it is available', async () => {
+    const user = userEvent.setup();
+    getLocalStorageMock.mockReturnValue(JSON.stringify(['333-r1', '222-r1', '333-r2']));
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: ActionType.RUN_RECIPES,
+      recipeId: 'pnw',
+      roundIds: ['333-r1', '222-r1'],
+    });
+    expect(setLocalStorageMock).toHaveBeenCalledWith(
+      'bulk-generation.round-order.test-comp',
+      JSON.stringify(['333-r1', '222-r1', '333-r2', '222-r2'])
+    );
+  });
+
+  it('resets persisted order back to schedule order', async () => {
+    const user = userEvent.setup();
+    getLocalStorageMock.mockReturnValue(JSON.stringify(['333-r1', '222-r1', '333-r2']));
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Reset to Schedule Order' }));
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(setLocalStorageMock).toHaveBeenLastCalledWith(
+      'bulk-generation.round-order.test-comp',
+      JSON.stringify(['222-r1', '333-r2', '333-r1', '222-r2'])
+    );
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: ActionType.RUN_RECIPES,
+      recipeId: 'pnw',
+      roundIds: ['222-r1', '333-r1'],
+    });
+  });
+});

--- a/src/pages/Competition/BulkGeneration/index.tsx
+++ b/src/pages/Competition/BulkGeneration/index.tsx
@@ -1,4 +1,6 @@
 import { BulkRoundTable } from './BulkRoundTable';
+import { BulkRoundGroupCountsDialog } from './BulkRoundGroupCountsDialog';
+import { BulkRoundPreviewDialog } from './BulkRoundPreviewDialog';
 import {
   buildBulkRoundRows,
   defaultSelectedRoundIds,
@@ -10,7 +12,6 @@ import { Recipes } from '../../../lib/recipes';
 import { useBreadcrumbs } from '../../../providers/BreadcrumbsProvider';
 import { useAppDispatch, useAppSelector } from '../../../store';
 import { partialUpdateWCIF } from '../../../store/actions';
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import {
   Alert,
@@ -89,6 +90,8 @@ const BulkGenerationPage = () => {
   const [selectedRoundIds, setSelectedRoundIds] = useState<Set<string>>(new Set());
   const [generationStatus, setGenerationStatus] = useState<string | null>(null);
   const [generationError, setGenerationError] = useState<string | null>(null);
+  const [previewRoundId, setPreviewRoundId] = useState<string | null>(null);
+  const [configureGroupsRoundId, setConfigureGroupsRoundId] = useState<string | null>(null);
 
   useEffect(() => {
     setBreadcrumbs([{ text: 'Bulk Generate' }]);
@@ -235,6 +238,17 @@ const BulkGenerationPage = () => {
 
   return (
     <Stack spacing={2}>
+      <BulkRoundPreviewDialog
+        wcif={wcif}
+        roundId={previewRoundId}
+        onClose={() => setPreviewRoundId(null)}
+      />
+      <BulkRoundGroupCountsDialog
+        wcif={wcif}
+        roundId={configureGroupsRoundId}
+        onClose={() => setConfigureGroupsRoundId(null)}
+      />
+
       <Stack
         direction={{ xs: 'column', md: 'row' }}
         spacing={2}
@@ -259,17 +273,11 @@ const BulkGenerationPage = () => {
         </FormControl>
         <Button
           variant="contained"
-          startIcon={<AutoFixHighIcon />}
           disabled={generating || selectedOrderedRoundIds.length === 0}
           onClick={handleGenerate}>
           Generate
         </Button>
       </Stack>
-
-      <Alert severity="info">
-        Only rounds with competitors can be selected. Selected rounds run in the displayed order.
-        Existing groups and assignments are preserved.
-      </Alert>
 
       {generationStatus && <Alert severity="info">{generationStatus}</Alert>}
       {generationError && <Alert severity="error">{generationError}</Alert>}
@@ -283,6 +291,8 @@ const BulkGenerationPage = () => {
           disabled={generating}
           onToggleRound={handleToggleRound}
           onMoveRound={handleMoveRound}
+          onPreviewRound={setPreviewRoundId}
+          onConfigureGroups={setConfigureGroupsRoundId}
         />
       )}
 

--- a/src/pages/Competition/BulkGeneration/index.tsx
+++ b/src/pages/Competition/BulkGeneration/index.tsx
@@ -1,0 +1,195 @@
+import { BulkRoundTable } from './BulkRoundTable';
+import {
+  buildBulkRoundRows,
+  defaultSelectedRoundIds,
+  mergeRoundOrder,
+  scheduleOrderedRoundIds,
+} from './bulkRoundRows';
+import { getLocalStorage, setLocalStorage } from '../../../lib/api';
+import { Recipes } from '../../../lib/recipes';
+import { useBreadcrumbs } from '../../../providers/BreadcrumbsProvider';
+import { useAppDispatch, useAppSelector } from '../../../store';
+import { runRecipes } from '../../../store/actions';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import {
+  Alert,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+
+const moveRoundId = (roundIds: string[], roundId: string, direction: -1 | 1) => {
+  const fromIndex = roundIds.indexOf(roundId);
+  const toIndex = fromIndex + direction;
+  if (fromIndex === -1 || toIndex < 0 || toIndex >= roundIds.length) {
+    return roundIds;
+  }
+
+  const nextRoundIds = [...roundIds];
+  const [movedRoundId] = nextRoundIds.splice(fromIndex, 1);
+  nextRoundIds.splice(toIndex, 0, movedRoundId);
+  return nextRoundIds;
+};
+
+const roundOrderStorageKey = (competitionId: string) =>
+  `bulk-generation.round-order.${competitionId}`;
+
+const parsePersistedRoundOrder = (value: string | null) => {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsedValue = JSON.parse(value);
+    return Array.isArray(parsedValue)
+      ? parsedValue.filter((roundId): roundId is string => typeof roundId === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const BulkGenerationPage = () => {
+  const dispatch = useAppDispatch();
+  const wcif = useAppSelector((state) => state.wcif);
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const rows = useMemo(() => (wcif ? buildBulkRoundRows(wcif) : []), [wcif]);
+  const [recipeId, setRecipeId] = useState('pnw');
+  const [orderedRoundIds, setOrderedRoundIds] = useState<string[]>([]);
+  const [selectedRoundIds, setSelectedRoundIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setBreadcrumbs([{ text: 'Bulk Generate' }]);
+  }, [setBreadcrumbs]);
+
+  useEffect(() => {
+    if (!wcif?.id) {
+      return;
+    }
+
+    const scheduleOrder = scheduleOrderedRoundIds(rows);
+    const persistedOrder = parsePersistedRoundOrder(getLocalStorage(roundOrderStorageKey(wcif.id)));
+    const nextOrder = mergeRoundOrder(scheduleOrder, persistedOrder);
+
+    setLocalStorage(roundOrderStorageKey(wcif.id), JSON.stringify(nextOrder));
+    setOrderedRoundIds(nextOrder);
+    setSelectedRoundIds(defaultSelectedRoundIds(rows));
+  }, [rows, wcif?.id]);
+
+  const orderedRows = useMemo(
+    () =>
+      orderedRoundIds
+        .map((roundId) => rows.find((row) => row.roundId === roundId))
+        .filter((row): row is NonNullable<typeof row> => Boolean(row)),
+    [orderedRoundIds, rows]
+  );
+
+  const selectedOrderedRoundIds = orderedRows
+    .filter((row) => row.selectable && selectedRoundIds.has(row.roundId))
+    .map((row) => row.roundId);
+
+  const handleToggleRound = (roundId: string) => {
+    if (!rows.find((row) => row.roundId === roundId)?.selectable) {
+      return;
+    }
+
+    setSelectedRoundIds((currentRoundIds) => {
+      const nextRoundIds = new Set(currentRoundIds);
+      if (nextRoundIds.has(roundId)) {
+        nextRoundIds.delete(roundId);
+      } else {
+        nextRoundIds.add(roundId);
+      }
+      return nextRoundIds;
+    });
+  };
+
+  const handleMoveRound = (roundId: string, direction: -1 | 1) => {
+    setOrderedRoundIds((currentRoundIds) => {
+      const nextRoundIds = moveRoundId(currentRoundIds, roundId, direction);
+      if (wcif?.id) {
+        setLocalStorage(roundOrderStorageKey(wcif.id), JSON.stringify(nextRoundIds));
+      }
+      return nextRoundIds;
+    });
+  };
+
+  const handleResetOrder = () => {
+    const scheduleOrder = scheduleOrderedRoundIds(rows);
+    if (wcif?.id) {
+      setLocalStorage(roundOrderStorageKey(wcif.id), JSON.stringify(scheduleOrder));
+    }
+    setOrderedRoundIds(scheduleOrder);
+  };
+
+  const handleGenerate = () => {
+    dispatch(runRecipes(selectedOrderedRoundIds, recipeId));
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={2}
+        alignItems={{ xs: 'stretch', md: 'center' }}>
+        <Typography variant="h5" component="h1" sx={{ flexGrow: 1 }}>
+          Bulk Generate
+        </Typography>
+        <FormControl size="small" sx={{ minWidth: 220 }}>
+          <InputLabel id="bulk-recipe-select-label">Recipe</InputLabel>
+          <Select
+            labelId="bulk-recipe-select-label"
+            label="Recipe"
+            value={recipeId}
+            onChange={(event) => setRecipeId(String(event.target.value))}>
+            {Recipes.map((recipe) => (
+              <MenuItem key={recipe.id} value={recipe.id}>
+                {recipe.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button
+          variant="contained"
+          startIcon={<AutoFixHighIcon />}
+          disabled={selectedOrderedRoundIds.length === 0}
+          onClick={handleGenerate}>
+          Generate
+        </Button>
+      </Stack>
+
+      <Alert severity="info">
+        Only rounds with competitors can be selected. Selected rounds run in the displayed order.
+        Existing groups and assignments are preserved.
+      </Alert>
+
+      {orderedRows.length === 0 ? (
+        <Alert severity="warning">No normal non-distributed rounds found.</Alert>
+      ) : (
+        <BulkRoundTable
+          rows={orderedRows}
+          selectedRoundIds={selectedRoundIds}
+          onToggleRound={handleToggleRound}
+          onMoveRound={handleMoveRound}
+        />
+      )}
+
+      <Stack direction="row" justifyContent="flex-end">
+        <Button
+          startIcon={<RestartAltIcon />}
+          disabled={orderedRows.length === 0}
+          onClick={handleResetOrder}>
+          Reset to Schedule Order
+        </Button>
+      </Stack>
+    </Stack>
+  );
+};
+
+export default BulkGenerationPage;

--- a/src/pages/Competition/BulkGeneration/index.tsx
+++ b/src/pages/Competition/BulkGeneration/index.tsx
@@ -9,7 +9,7 @@ import { getLocalStorage, setLocalStorage } from '../../../lib/api';
 import { Recipes } from '../../../lib/recipes';
 import { useBreadcrumbs } from '../../../providers/BreadcrumbsProvider';
 import { useAppDispatch, useAppSelector } from '../../../store';
-import { runRecipes } from '../../../store/actions';
+import { partialUpdateWCIF } from '../../../store/actions';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import {
@@ -22,7 +22,11 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  BulkGenerationWorkerRequest,
+  BulkGenerationWorkerResponse,
+} from './bulkGenerationWorkerTypes';
 
 const moveRoundId = (roundIds: string[], roundId: string, direction: -1 | 1) => {
   const fromIndex = roundIds.indexOf(roundId);
@@ -55,18 +59,47 @@ const parsePersistedRoundOrder = (value: string | null) => {
   }
 };
 
+const progressText = (
+  progress: Extract<BulkGenerationWorkerResponse, { type: 'progress' }>,
+  labelForRound: (roundId: string) => string
+) => {
+  if (progress.phase === 'fixing') {
+    return 'Fixing group assignments';
+  }
+
+  if (progress.roundId && progress.phase === 'staff') {
+    return `Generating staff assignments for ${labelForRound(progress.roundId)}`;
+  }
+
+  if (progress.roundId) {
+    return `Generating for ${labelForRound(progress.roundId)}`;
+  }
+
+  return 'Generating';
+};
+
 const BulkGenerationPage = () => {
   const dispatch = useAppDispatch();
   const wcif = useAppSelector((state) => state.wcif);
+  const workerRef = useRef<Worker | null>(null);
   const { setBreadcrumbs } = useBreadcrumbs();
   const rows = useMemo(() => (wcif ? buildBulkRoundRows(wcif) : []), [wcif]);
   const [recipeId, setRecipeId] = useState('pnw');
   const [orderedRoundIds, setOrderedRoundIds] = useState<string[]>([]);
   const [selectedRoundIds, setSelectedRoundIds] = useState<Set<string>>(new Set());
+  const [generationStatus, setGenerationStatus] = useState<string | null>(null);
+  const [generationError, setGenerationError] = useState<string | null>(null);
 
   useEffect(() => {
     setBreadcrumbs([{ text: 'Bulk Generate' }]);
   }, [setBreadcrumbs]);
+
+  useEffect(
+    () => () => {
+      workerRef.current?.terminate();
+    },
+    []
+  );
 
   useEffect(() => {
     if (!wcif?.id) {
@@ -93,8 +126,15 @@ const BulkGenerationPage = () => {
   const selectedOrderedRoundIds = orderedRows
     .filter((row) => row.selectable && selectedRoundIds.has(row.roundId))
     .map((row) => row.roundId);
+  const generating = Boolean(generationStatus);
+  const labelForRound = (roundId: string) =>
+    rows.find((row) => row.roundId === roundId)?.label ?? roundId;
 
   const handleToggleRound = (roundId: string) => {
+    if (generating) {
+      return;
+    }
+
     if (!rows.find((row) => row.roundId === roundId)?.selectable) {
       return;
     }
@@ -111,6 +151,10 @@ const BulkGenerationPage = () => {
   };
 
   const handleMoveRound = (roundId: string, direction: -1 | 1) => {
+    if (generating) {
+      return;
+    }
+
     setOrderedRoundIds((currentRoundIds) => {
       const nextRoundIds = moveRoundId(currentRoundIds, roundId, direction);
       if (wcif?.id) {
@@ -121,6 +165,10 @@ const BulkGenerationPage = () => {
   };
 
   const handleResetOrder = () => {
+    if (generating) {
+      return;
+    }
+
     const scheduleOrder = scheduleOrderedRoundIds(rows);
     if (wcif?.id) {
       setLocalStorage(roundOrderStorageKey(wcif.id), JSON.stringify(scheduleOrder));
@@ -129,7 +177,60 @@ const BulkGenerationPage = () => {
   };
 
   const handleGenerate = () => {
-    dispatch(runRecipes(selectedOrderedRoundIds, recipeId));
+    if (!wcif || selectedOrderedRoundIds.length === 0 || generating) {
+      return;
+    }
+
+    workerRef.current?.terminate();
+    const worker = new Worker(new URL('./bulkGeneration.worker.ts', import.meta.url), {
+      type: 'module',
+    });
+    workerRef.current = worker;
+    setGenerationError(null);
+    setGenerationStatus('Starting bulk generation');
+
+    worker.onmessage = (event: MessageEvent<BulkGenerationWorkerResponse>) => {
+      const message = event.data;
+
+      if (message.type === 'progress') {
+        setGenerationStatus(progressText(message, labelForRound));
+        return;
+      }
+
+      if (message.type === 'complete') {
+        dispatch(
+          partialUpdateWCIF({
+            events: message.wcif.events,
+            persons: message.wcif.persons,
+            schedule: message.wcif.schedule,
+          })
+        );
+        setGenerationStatus(null);
+        worker.terminate();
+        workerRef.current = null;
+        return;
+      }
+
+      setGenerationError(message.message);
+      setGenerationStatus(null);
+      worker.terminate();
+      workerRef.current = null;
+    };
+
+    worker.onerror = () => {
+      setGenerationError('Bulk generation failed');
+      setGenerationStatus(null);
+      worker.terminate();
+      workerRef.current = null;
+    };
+
+    const message: BulkGenerationWorkerRequest = {
+      type: 'runBulkGeneration',
+      wcif,
+      recipeId,
+      roundIds: selectedOrderedRoundIds,
+    };
+    worker.postMessage(message);
   };
 
   return (
@@ -147,6 +248,7 @@ const BulkGenerationPage = () => {
             labelId="bulk-recipe-select-label"
             label="Recipe"
             value={recipeId}
+            disabled={generating}
             onChange={(event) => setRecipeId(String(event.target.value))}>
             {Recipes.map((recipe) => (
               <MenuItem key={recipe.id} value={recipe.id}>
@@ -158,7 +260,7 @@ const BulkGenerationPage = () => {
         <Button
           variant="contained"
           startIcon={<AutoFixHighIcon />}
-          disabled={selectedOrderedRoundIds.length === 0}
+          disabled={generating || selectedOrderedRoundIds.length === 0}
           onClick={handleGenerate}>
           Generate
         </Button>
@@ -169,12 +271,16 @@ const BulkGenerationPage = () => {
         Existing groups and assignments are preserved.
       </Alert>
 
+      {generationStatus && <Alert severity="info">{generationStatus}</Alert>}
+      {generationError && <Alert severity="error">{generationError}</Alert>}
+
       {orderedRows.length === 0 ? (
         <Alert severity="warning">No normal non-distributed rounds found.</Alert>
       ) : (
         <BulkRoundTable
           rows={orderedRows}
           selectedRoundIds={selectedRoundIds}
+          disabled={generating}
           onToggleRound={handleToggleRound}
           onMoveRound={handleMoveRound}
         />
@@ -183,7 +289,7 @@ const BulkGenerationPage = () => {
       <Stack direction="row" justifyContent="flex-end">
         <Button
           startIcon={<RestartAltIcon />}
-          disabled={orderedRows.length === 0}
+          disabled={generating || orderedRows.length === 0}
           onClick={handleResetOrder}>
           Reset to Schedule Order
         </Button>

--- a/src/pages/Competition/Round/RoundContainer.tsx
+++ b/src/pages/Competition/Round/RoundContainer.tsx
@@ -8,6 +8,7 @@ import GroupCard from '../../../components/GroupCard';
 import { RawRoundActivitiesDataDialog } from '../../../dialogs/RawRoundActivitiesDataDialog';
 import { RawRoundDataDialog } from '../../../dialogs/RawRoundDataDialog';
 import { RoundActionButtons } from '../../../components/RoundActionButtons';
+import { RoundAssignmentCountsTable } from '../../../components/RoundAssignmentCountsTable';
 import { RoundStatisticsCard } from '../../../components/RoundStatisticsCard';
 import { useRoundActions } from './hooks/useRoundActions';
 import { useRoundData } from './hooks/useRoundData';
@@ -44,7 +45,7 @@ const RoundContainer = ({ roundId, activityCode, eventId, round }: RoundContaine
     adamRoundConfig,
   } = useRoundData(activityCode, round);
 
-  const { handleGenerateAssignments, handleResetAll, handleResetNonScrambling } = useRoundActions({
+  const { handleResetAll, handleResetNonScrambling } = useRoundActions({
     round,
     groups,
     roundActivities,
@@ -115,7 +116,6 @@ const RoundContainer = ({ roundId, activityCode, eventId, round }: RoundContaine
                 personsShouldBeInRound={personsShouldBeInRound}
                 activityCode={activityCode}
                 onConfigureAssignments={() => dialogs.configureAssignments.setOpen(true)}
-                onGenerateAssignments={handleGenerateAssignments}
                 recipeId={recipeId}
                 onChangeRecipeId={handleChangeRecipeId}
                 onRunRecipe={handleRunRecipe}
@@ -146,6 +146,10 @@ const RoundContainer = ({ roundId, activityCode, eventId, round }: RoundContaine
           {sortedGroups.map((group) => (
             <GroupCard key={group.id} groupActivity={group} />
           ))}
+        </Grid>
+
+        <Grid item>
+          <RoundAssignmentCountsTable groups={groups} persons={wcif?.persons ?? []} />
         </Grid>
 
         <ConfigureAssignmentsDialog

--- a/src/pages/Competition/index.tsx
+++ b/src/pages/Competition/index.tsx
@@ -7,3 +7,4 @@ export { default as Assignments } from './Assignments';
 export { default as Import } from './Import';
 export { default as Export } from './Export';
 export { default as ScramblerSchedule } from './ScramblerSchedule';
+export { default as BulkGeneration } from './BulkGeneration';

--- a/src/store/actions.test.ts
+++ b/src/store/actions.test.ts
@@ -12,6 +12,7 @@ import {
   partialUpdateWCIF,
   removePersonAssignments,
   resetAllGroupAssignments,
+  runRecipes,
   togglePersonRole,
   updateGlobalExtension,
   updateGroupCount,
@@ -143,6 +144,11 @@ describe('store actions', () => {
       type: ActionType.GENERATE_ASSIGNMENTS,
       roundId: '333-r1',
       options: { sortOrganizationStaffInLastGroups: true },
+    });
+    expect(runRecipes(['333-r1', '222-r1'], 'pnw')).toEqual({
+      type: ActionType.RUN_RECIPES,
+      roundIds: ['333-r1', '222-r1'],
+      recipeId: 'pnw',
     });
     expect(editActivity({ id: 10 }, { name: 'Updated' })).toEqual({
       type: ActionType.EDIT_ACTIVITY,

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -47,6 +47,7 @@ export const ActionType = {
   RESET_ALL_GROUP_ASSIGNMENTS: 'reset_all_group_assignments',
   GENERATE_ASSIGNMENTS: 'generate_assignments',
   RUN_RECIPE: 'run_recipe',
+  RUN_RECIPES: 'run_recipes',
   GENERATE_ROUND_ATTEMPT_ASSIGNMENTS: 'generate_round_attempt_assignments',
   EDIT_ACTIVITY: 'edit_activity',
   UPDATE_GLOBAL_EXTENSION: 'update_global_extension',
@@ -377,6 +378,19 @@ export const runRecipe = (
 ): ReduxAction<typeof ActionType.RUN_RECIPE, RunRecipePayload> => ({
   type: ActionType.RUN_RECIPE,
   roundId,
+  recipeId,
+});
+
+export type RunRecipesPayload = {
+  roundIds: string[];
+  recipeId: string;
+};
+export const runRecipes = (
+  roundIds: string[],
+  recipeId: string
+): ReduxAction<typeof ActionType.RUN_RECIPES, RunRecipesPayload> => ({
+  type: ActionType.RUN_RECIPES,
+  roundIds,
   recipeId,
 });
 

--- a/src/store/reducerHandlers.ts
+++ b/src/store/reducerHandlers.ts
@@ -173,6 +173,7 @@ export const reducers: Record<string, ReducerFunction> = {
   },
   [ActionType.GENERATE_ASSIGNMENTS]: Reducers.generateAssignments,
   [ActionType.RUN_RECIPE]: Reducers.runRecipe,
+  [ActionType.RUN_RECIPES]: Reducers.runRecipes,
   [ActionType.GENERATE_ROUND_ATTEMPT_ASSIGNMENTS]: (
     state,
     action: GenerateRoundAttemptAssignmentsPayload

--- a/src/store/reducers/runRecipe.test.ts
+++ b/src/store/reducers/runRecipe.test.ts
@@ -1,4 +1,5 @@
 import { runRecipe } from './runRecipe';
+import { runRecipes } from './runRecipe';
 import {
   buildActivity,
   buildEvent,
@@ -15,8 +16,10 @@ import {
   type Competition,
   type EventId,
   type Person,
+  type Round,
 } from '@wca/helpers';
 import { describe, expect, it } from 'vitest';
+import { getRoundConfigExtensionData } from '../../lib/wcif/extensions/delegateDashboard/delegateDashboard';
 
 interface CompetitionOptions {
   groupCount?: number;
@@ -30,6 +33,11 @@ const acceptedRegistration = (registrantId: number) => ({
   isCompeting: true,
   comments: undefined,
   wcaRegistrationId: registrantId,
+});
+
+const acceptedRegistrationForEvents = (registrantId: number, eventIds: EventId[]) => ({
+  ...acceptedRegistration(registrantId),
+  eventIds,
 });
 
 const personalBest = (worldRanking: number, best: number) => ({
@@ -78,6 +86,14 @@ const buildTimedGroup = (
     activityCode,
     startTime,
     endTime,
+  });
+
+const buildTimedRoundActivity = (id: number, activityCode: string, childActivities: Activity[]) =>
+  buildActivity({
+    id,
+    name: activityCode,
+    activityCode,
+    childActivities,
   });
 
 const buildRoundActivity = (
@@ -171,6 +187,27 @@ const activityForAssignment = (wcif: Competition, person: Person | undefined) =>
   return allActivities(wcif).find((activity) => activity.id === assignment.activityId);
 };
 
+const competitorAssignmentInRound = (
+  wcif: Competition,
+  person: Person | undefined,
+  roundId: string
+) => {
+  const activityIds = new Set(
+    allActivities(wcif)
+      .filter((activity) => activity.activityCode.startsWith(`${roundId}-g`))
+      .map((activity) => activity.id)
+  );
+
+  return person?.assignments?.find(
+    (personAssignment) =>
+      personAssignment.assignmentCode === 'competitor' &&
+      activityIds.has(personAssignment.activityId)
+  );
+};
+
+const roundById = (wcif: Competition, roundId: string) =>
+  wcif.events.flatMap((event) => event.rounds).find((round) => round.id === roundId);
+
 const competitorGroupNumber = (wcif: Competition, person: Person | undefined) => {
   const activity = activityForAssignment(wcif, person);
   if (!activity) return undefined;
@@ -248,6 +285,21 @@ const assignmentCount = (person: Person | undefined, assignmentCode: AssignmentC
   ).length ?? 0;
 
 describe('runRecipe', () => {
+  it('stores the selected recipe config on the generated round', () => {
+    const updatedState = runRecipe(
+      buildState(buildCompetition([competitor(1), competitor(2)], { includeGroups: false })),
+      {
+        roundId: '333-r1',
+        recipeId: 'balanced',
+      }
+    );
+
+    const updatedRound = roundById(updatedState.wcif as Competition, '333-r1');
+    expect(getRoundConfigExtensionData(updatedRound as NonNullable<typeof updatedRound>)).toMatchObject({
+      recipe: { id: 'balanced' },
+    });
+  });
+
   it('assigns every finalist into the generated group for one-group finals', () => {
     const wcif = runPnwRecipe(
       Array.from({ length: 4 }, (_, index) => competitor(index + 1)),
@@ -581,5 +633,98 @@ describe('runRecipe', () => {
       allActivities(updatedWcif).find((activity) => activity.activityCode === '222-r1')
         ?.childActivities
     ).toEqual(otherRound.childActivities);
+  });
+});
+
+describe('runRecipes', () => {
+  const buildBulkCompetition = () => {
+    const persons = [1, 2, 3].map((registrantId) =>
+      competitor(registrantId, {
+        registration: acceptedRegistrationForEvents(registrantId, [
+          '222' as EventId,
+          '333' as EventId,
+        ]),
+        personalBests: [
+          personalBest(registrantId, 1000 + registrantId),
+          {
+            ...personalBest(registrantId, 900 + registrantId),
+            eventId: '222' as EventId,
+          },
+        ],
+      })
+    );
+    const round222 = buildTimedRoundActivity(2, '222-r1', [
+      buildTimedGroup(201, '222-r1-g1', '2024-01-01T10:00:00.000Z', '2024-01-01T10:10:00.000Z'),
+    ]);
+    const round333 = buildTimedRoundActivity(1, '333-r1', [
+      buildTimedGroup(101, '333-r1-g1', '2024-01-01T10:10:00.000Z', '2024-01-01T10:20:00.000Z'),
+      buildTimedGroup(102, '333-r1-g2', '2024-01-01T11:00:00.000Z', '2024-01-01T11:10:00.000Z'),
+    ]);
+
+    return buildWcifWithEvents(
+      [round333, round222],
+      [
+        buildEvent({ id: '333', rounds: [buildRound({ id: '333-r1' })] }),
+        buildEvent({ id: '222', rounds: [buildRound({ id: '222-r1' })] }),
+      ],
+      persons
+    );
+  };
+
+  it('runs the same recipe across selected rounds in order with accumulating WCIF context', () => {
+    const updatedState = runRecipes(buildState(buildBulkCompetition()), {
+      recipeId: 'pnw',
+      roundIds: ['222-r1', '333-r1'],
+    });
+    const updatedWcif = updatedState.wcif as Competition;
+    const person = personById(updatedWcif, 1);
+
+    expect(competitorAssignmentInRound(updatedWcif, person, '222-r1')).toBeDefined();
+    expect(competitorAssignmentInRound(updatedWcif, person, '333-r1')).toBeDefined();
+    expect(competitorGroupNumberInRound(updatedWcif, person, '333-r1')).toBe(2);
+    expect(updatedState.needToSave).toBe(true);
+    expect(Array.from(updatedState.changedKeys).sort()).toEqual(['events', 'persons', 'schedule']);
+  });
+
+  it('preserves existing groups and assignments while filling missing round data', () => {
+    const existingAssignment = assignment(101, 'competitor');
+    const wcif = {
+      ...buildBulkCompetition(),
+      persons: [
+        competitor(1, {
+          registration: acceptedRegistrationForEvents(1, ['222' as EventId, '333' as EventId]),
+          assignments: [existingAssignment],
+        }),
+        competitor(2, {
+          registration: acceptedRegistrationForEvents(2, ['222' as EventId, '333' as EventId]),
+        }),
+      ],
+    };
+
+    const updatedWcif = runRecipes(buildState(wcif), {
+      recipeId: 'pnw',
+      roundIds: ['333-r1', '222-r1'],
+    }).wcif as Competition;
+
+    expect(personById(updatedWcif, 1)?.assignments).toContainEqual(existingAssignment);
+    expect(
+      allActivities(updatedWcif).find((activity) => activity.activityCode === '333-r1')
+        ?.childActivities
+    ).toHaveLength(2);
+    expect(competitorAssignmentInRound(updatedWcif, personById(updatedWcif, 2), '333-r1')).toBeDefined();
+  });
+
+  it('stores the selected recipe config on every generated round', () => {
+    const updatedWcif = runRecipes(buildState(buildBulkCompetition()), {
+      recipeId: 'mca',
+      roundIds: ['333-r1', '222-r1'],
+    }).wcif as Competition;
+
+    expect(getRoundConfigExtensionData(roundById(updatedWcif, '333-r1') as Round)).toMatchObject({
+      recipe: { id: 'mca' },
+    });
+    expect(getRoundConfigExtensionData(roundById(updatedWcif, '222-r1') as Round)).toMatchObject({
+      recipe: { id: 'mca' },
+    });
   });
 });

--- a/src/store/reducers/runRecipe.test.ts
+++ b/src/store/reducers/runRecipe.test.ts
@@ -62,8 +62,22 @@ const buildGroup = (id: number, groupNumber: number, stageNumber: number): Activ
     id,
     name: `Stage ${stageNumber} Group ${groupNumber}`,
     activityCode: `333-r1-g${groupNumber}`,
-    startTime: `2024-01-01T10:0${groupNumber}:00Z`,
-    endTime: `2024-01-01T10:1${groupNumber}:00Z`,
+    startTime: new Date(Date.UTC(2024, 0, 1, 10, (groupNumber - 1) * 10)).toISOString(),
+    endTime: new Date(Date.UTC(2024, 0, 1, 10, groupNumber * 10)).toISOString(),
+  });
+
+const buildTimedGroup = (
+  id: number,
+  activityCode: string,
+  startTime: string,
+  endTime: string
+): Activity =>
+  buildActivity({
+    id,
+    name: activityCode,
+    activityCode,
+    startTime,
+    endTime,
   });
 
 const buildRoundActivity = (
@@ -162,6 +176,26 @@ const competitorGroupNumber = (wcif: Competition, person: Person | undefined) =>
   if (!activity) return undefined;
 
   return parseActivityCode(activity.activityCode).groupNumber;
+};
+
+const competitorGroupNumberInRound = (
+  wcif: Competition,
+  person: Person | undefined,
+  roundId: string
+) => {
+  const activityIds = new Set(
+    allActivities(wcif)
+      .filter((activity) => activity.activityCode.startsWith(`${roundId}-g`))
+      .map((activity) => activity.id)
+  );
+  const assignment = person?.assignments?.find(
+    (personAssignment) =>
+      personAssignment.assignmentCode === 'competitor' &&
+      activityIds.has(personAssignment.activityId)
+  );
+  const activity = allActivities(wcif).find((candidate) => candidate.id === assignment?.activityId);
+
+  return activity ? parseActivityCode(activity.activityCode).groupNumber : undefined;
 };
 
 const competitorStageNumber = (wcif: Competition, person: Person | undefined) => {
@@ -427,5 +461,125 @@ describe('runRecipe', () => {
     const wcif = runPnwRecipe([groupOneEthan, ...fullOtherGroups, unassignedEthan]);
 
     expect(competitorGroupNumber(wcif, personById(wcif, 20))).not.toBe(1);
+  });
+
+  it('still gives everyone a competitor assignment when timing options are poor', () => {
+    const wcif = runPnwRecipe([
+      competitor(1, {
+        name: 'Alpha Staff',
+        assignments: [assignment(102, 'staff-judge')],
+      }),
+      competitor(2, {
+        name: 'Bravo Staff',
+        assignments: [assignment(102, 'staff-runner')],
+      }),
+      competitor(3, { name: 'Charlie Competitor' }),
+    ], { groupCount: 2 });
+
+    expect(wcif.persons.map((person) => assignmentCount(person, 'competitor'))).toEqual([
+      1, 1, 1,
+    ]);
+  });
+
+  it('uses cross-round competitor assignments as read-only spacing context', () => {
+    const nearActivity = buildTimedGroup(
+      101,
+      '333-r1-g1',
+      '2024-01-01T10:10:00.000Z',
+      '2024-01-01T10:20:00.000Z'
+    );
+    const farActivity = buildTimedGroup(
+      102,
+      '333-r1-g2',
+      '2024-01-01T11:00:00.000Z',
+      '2024-01-01T11:10:00.000Z'
+    );
+    const otherRoundActivity = buildTimedGroup(
+      201,
+      '222-r1-g1',
+      '2024-01-01T10:00:00.000Z',
+      '2024-01-01T10:10:00.000Z'
+    );
+    const roundActivity = buildActivity({
+      id: 1,
+      activityCode: '333-r1',
+      childActivities: [nearActivity, farActivity],
+    });
+    const otherRound = buildActivity({
+      id: 2,
+      activityCode: '222-r1',
+      childActivities: [otherRoundActivity],
+    });
+    const person = competitor(1, {
+      assignments: [assignment(201, 'competitor')],
+    });
+    const wcif = buildWcifWithEvents(
+      [roundActivity, otherRound],
+      [
+        buildEvent({ id: '333', rounds: [buildRound({ id: '333-r1' })] }),
+        buildEvent({ id: '222', rounds: [buildRound({ id: '222-r1' })] }),
+      ],
+      [person]
+    );
+
+    const updatedWcif = runRecipe(buildState(wcif), {
+      roundId: '333-r1',
+      recipeId: 'pnw',
+    }).wcif as Competition;
+
+    expect(competitorGroupNumberInRound(updatedWcif, personById(updatedWcif, 1), '333-r1')).toBe(
+      2
+    );
+    expect(personById(updatedWcif, 1)?.assignments).toContainEqual(assignment(201, 'competitor'));
+  });
+
+  it('does not change assignments from other rounds when generating a single round', () => {
+    const otherRoundAssignment = assignment(201, 'staff-judge');
+    const roundActivity = buildActivity({
+      id: 1,
+      activityCode: '333-r1',
+      childActivities: [buildGroup(101, 1, 1), buildGroup(102, 2, 1)],
+    });
+    const otherRound = buildActivity({
+      id: 2,
+      activityCode: '222-r1',
+      childActivities: [
+        buildTimedGroup(
+          201,
+          '222-r1-g1',
+          '2024-01-01T12:00:00.000Z',
+          '2024-01-01T12:10:00.000Z'
+        ),
+      ],
+    });
+    const wcif = buildWcifWithEvents(
+      [roundActivity, otherRound],
+      [
+        buildEvent({ id: '333', rounds: [buildRound({ id: '333-r1' })] }),
+        buildEvent({ id: '222', rounds: [buildRound({ id: '222-r1' })] }),
+      ],
+      [
+        competitor(1, {
+          assignments: [otherRoundAssignment],
+        }),
+        competitor(2),
+      ]
+    );
+
+    const updatedWcif = runRecipe(buildState(wcif), {
+      roundId: '333-r1',
+      recipeId: 'pnw',
+    }).wcif as Competition;
+
+    expect(personById(updatedWcif, 1)?.assignments).toContainEqual(otherRoundAssignment);
+    expect(
+      personById(updatedWcif, 1)?.assignments?.filter(
+        (personAssignment) => personAssignment.activityId === 201
+      )
+    ).toEqual([otherRoundAssignment]);
+    expect(
+      allActivities(updatedWcif).find((activity) => activity.activityCode === '222-r1')
+        ?.childActivities
+    ).toEqual(otherRound.childActivities);
   });
 });

--- a/src/store/reducers/runRecipe.test.ts
+++ b/src/store/reducers/runRecipe.test.ts
@@ -1,0 +1,412 @@
+import { runRecipe } from './runRecipe';
+import {
+  buildActivity,
+  buildEvent,
+  buildPerson,
+  buildRound,
+  buildState,
+  buildWcifWithEvents,
+} from './_tests_/helpers';
+import {
+  parseActivityCode,
+  type Activity,
+  type Assignment,
+  type AssignmentCode,
+  type Competition,
+  type EventId,
+  type Person,
+} from '@wca/helpers';
+import { describe, expect, it } from 'vitest';
+
+interface CompetitionOptions {
+  groupCount?: number;
+  stageCount?: number;
+  includeGroups?: boolean;
+}
+
+const acceptedRegistration = (registrantId: number) => ({
+  status: 'accepted' as const,
+  eventIds: ['333' as EventId],
+  isCompeting: true,
+  comments: undefined,
+  wcaRegistrationId: registrantId,
+});
+
+const personalBest = (worldRanking: number, best: number) => ({
+  eventId: '333' as EventId,
+  type: 'average' as const,
+  best,
+  worldRanking,
+  continentalRanking: worldRanking,
+  nationalRanking: worldRanking,
+});
+
+const assignment = (activityId: number, assignmentCode: AssignmentCode): Assignment => ({
+  activityId,
+  assignmentCode,
+  stationNumber: null,
+});
+
+const competitor = (registrantId: number, overrides: Partial<Person> = {}) =>
+  buildPerson({
+    registrantId,
+    name: `Competitor ${registrantId}`,
+    wcaUserId: registrantId,
+    registration: acceptedRegistration(registrantId),
+    personalBests: [personalBest(registrantId, 1000 + registrantId)],
+    ...overrides,
+  });
+
+const buildGroup = (id: number, groupNumber: number, stageNumber: number): Activity =>
+  buildActivity({
+    id,
+    name: `Stage ${stageNumber} Group ${groupNumber}`,
+    activityCode: `333-r1-g${groupNumber}`,
+    startTime: `2024-01-01T10:0${groupNumber}:00Z`,
+    endTime: `2024-01-01T10:1${groupNumber}:00Z`,
+  });
+
+const buildRoundActivity = (
+  stageNumber: number,
+  groupCount: number,
+  includeGroups: boolean
+): Activity =>
+  buildActivity({
+    id: stageNumber,
+    name: `3x3 Round 1 Stage ${stageNumber}`,
+    activityCode: '333-r1',
+    childActivities: includeGroups
+      ? Array.from({ length: groupCount }, (_, index) =>
+          buildGroup(stageNumber * 100 + index + 1, index + 1, stageNumber)
+        )
+      : [],
+  });
+
+const buildCompetition = (
+  persons: Person[],
+  { groupCount = 3, stageCount = 1, includeGroups = true }: CompetitionOptions = {}
+): Competition => {
+  const round = buildRound({ id: '333-r1' });
+  const event = buildEvent({ id: '333', rounds: [round] });
+  const roundActivities = Array.from({ length: stageCount }, (_, index) =>
+    buildRoundActivity(index + 1, groupCount, includeGroups)
+  );
+  const wcif = buildWcifWithEvents(roundActivities, [event], persons);
+
+  return {
+    ...wcif,
+    schedule: {
+      ...wcif.schedule,
+      venues: [
+        {
+          ...wcif.schedule.venues[0],
+          rooms: roundActivities.map((roundActivity, index) => ({
+            id: index + 1,
+            name: `Stage ${index + 1}`,
+            color: '#000',
+            extensions: [],
+            activities: [roundActivity],
+          })),
+        },
+      ],
+    },
+  };
+};
+
+const runRecipeById = (
+  recipeId: string,
+  persons: Person[],
+  options: CompetitionOptions = {}
+): Competition =>
+  runRecipe(buildState(buildCompetition(persons, options)), {
+    roundId: '333-r1',
+    recipeId,
+  }).wcif as Competition;
+
+const runPnwRecipe = (persons: Person[], options: CompetitionOptions = {}) =>
+  runRecipeById('pnw', persons, options);
+
+const personById = (wcif: Competition, registrantId: number) =>
+  wcif.persons.find((person) => person.registrantId === registrantId);
+
+const competitorAssignment = (person: Person | undefined) =>
+  person?.assignments?.find((assignment) => assignment.assignmentCode === 'competitor');
+
+const allActivities = (wcif: Competition) =>
+  wcif.schedule.venues.flatMap((venue) =>
+    venue.rooms.flatMap((room) =>
+      room.activities.flatMap((activity) => [activity, ...(activity.childActivities ?? [])])
+    )
+  );
+
+const roomForActivity = (wcif: Competition, activityId: number) =>
+  wcif.schedule.venues
+    .flatMap((venue) => venue.rooms)
+    .find((room) =>
+      room.activities.some(
+        (activity) =>
+          activity.id === activityId ||
+          activity.childActivities?.some((childActivity) => childActivity.id === activityId)
+      )
+    );
+
+const activityForAssignment = (wcif: Competition, person: Person | undefined) => {
+  const assignment = competitorAssignment(person);
+  if (!assignment) return undefined;
+
+  return allActivities(wcif).find((activity) => activity.id === assignment.activityId);
+};
+
+const competitorGroupNumber = (wcif: Competition, person: Person | undefined) => {
+  const activity = activityForAssignment(wcif, person);
+  if (!activity) return undefined;
+
+  return parseActivityCode(activity.activityCode).groupNumber;
+};
+
+const competitorStageNumber = (wcif: Competition, person: Person | undefined) => {
+  const assignment = competitorAssignment(person);
+  if (!assignment) return undefined;
+
+  return roomForActivity(wcif, assignment.activityId)?.id;
+};
+
+const competitorCombo = (wcif: Competition, person: Person | undefined) => {
+  const stageNumber = competitorStageNumber(wcif, person);
+  const groupNumber = competitorGroupNumber(wcif, person);
+
+  return stageNumber && groupNumber ? `${stageNumber}:${groupNumber}` : undefined;
+};
+
+const valuesById = <T,>(wcif: Competition, registrantIds: number[], value: (person: Person) => T) =>
+  registrantIds.map((registrantId) => value(personById(wcif, registrantId) as Person));
+
+const countBy = <T extends string | number | symbol>(values: T[]) =>
+  values.reduce<Record<T, number>>(
+    (counts, value) => ({
+      ...counts,
+      [value]: (counts[value] ?? 0) + 1,
+    }),
+    {} as Record<T, number>
+  );
+
+const maxMinusMin = (counts: Record<string | number, number>) => {
+  const values = Object.values(counts);
+  return Math.max(...values) - Math.min(...values);
+};
+
+const firstTimerCountsByGroup = (wcif: Competition) =>
+  wcif.persons.reduce<Record<number, number>>((counts, person) => {
+    if (person.wcaId) return counts;
+
+    const groupNumber = competitorGroupNumber(wcif, person);
+    if (!groupNumber) return counts;
+
+    return {
+      ...counts,
+      [groupNumber]: (counts[groupNumber] ?? 0) + 1,
+    };
+  }, {});
+
+const assignmentCount = (person: Person | undefined, assignmentCode: AssignmentCode) =>
+  person?.assignments?.filter(
+    (personAssignment) => personAssignment.assignmentCode === assignmentCode
+  ).length ?? 0;
+
+describe('runRecipe', () => {
+  it('assigns every finalist into the generated group for one-group finals', () => {
+    const wcif = runPnwRecipe(
+      Array.from({ length: 4 }, (_, index) => competitor(index + 1)),
+      { includeGroups: false }
+    );
+
+    expect(wcif.schedule.venues[0].rooms[0].activities[0].childActivities).toHaveLength(1);
+    expect(wcif.persons.map((person) => competitorGroupNumber(wcif, person))).toEqual([
+      1, 1, 1, 1,
+    ]);
+    expect(wcif.persons.map((person) => assignmentCount(person, 'staff-judge'))).toEqual([
+      0, 0, 0, 0,
+    ]);
+  });
+
+  it('assigns staff competitors before staff assignments so they help after competing', () => {
+    const wcif = runPnwRecipe([
+      competitor(1, {
+        name: 'Staff In Middle Group',
+        assignments: [{ activityId: 102, assignmentCode: 'staff-judge', stationNumber: null }],
+      }),
+      competitor(2, {
+        name: 'Staff In First Group',
+        assignments: [{ activityId: 101, assignmentCode: 'staff-judge', stationNumber: null }],
+      }),
+      competitor(3),
+      competitor(4),
+    ]);
+
+    expect(competitorGroupNumber(wcif, personById(wcif, 1))).toBe(1);
+    expect(competitorGroupNumber(wcif, personById(wcif, 2))).toBe(3);
+  });
+
+  it('balances five delegates across group numbers and stages in a two-group two-stage round', () => {
+    const wcif = runPnwRecipe(
+      Array.from({ length: 5 }, (_, index) =>
+        competitor(index + 1, {
+          roles: [index === 1 ? 'trainee-delegate' : 'delegate'],
+        })
+      ),
+      { groupCount: 2, stageCount: 2 }
+    );
+
+    const delegateIds = [1, 2, 3, 4, 5];
+    const groupNumbers = valuesById(wcif, delegateIds, (person) =>
+      competitorGroupNumber(wcif, person)
+    ).filter(Boolean) as number[];
+    const stageNumbers = valuesById(wcif, delegateIds, (person) =>
+      competitorStageNumber(wcif, person)
+    ).filter(Boolean) as number[];
+
+    expect(new Set(groupNumbers)).toEqual(new Set([1, 2]));
+    expect(new Set(stageNumbers)).toEqual(new Set([1, 2]));
+    expect(maxMinusMin(countBy(groupNumbers))).toBeLessThanOrEqual(1);
+    expect(maxMinusMin(countBy(stageNumbers))).toBeLessThanOrEqual(1);
+  });
+
+  it('puts three delegates in different group numbers in a five-group two-stage round', () => {
+    const wcif = runPnwRecipe(
+      Array.from({ length: 3 }, (_, index) =>
+        competitor(index + 1, {
+          roles: [index === 2 ? 'organizer' : 'delegate'],
+        })
+      ),
+      { groupCount: 5, stageCount: 2 }
+    );
+
+    const delegateIds = [1, 2, 3];
+    const groupNumbers = valuesById(wcif, delegateIds, (person) =>
+      competitorGroupNumber(wcif, person)
+    );
+    const combos = valuesById(wcif, delegateIds, (person) => competitorCombo(wcif, person));
+
+    expect(new Set(groupNumbers).size).toBe(3);
+    expect(new Set(combos).size).toBe(3);
+  });
+
+  it('keeps first timers out of the last group and distributes them evenly across eligible groups', () => {
+    const firstTimers = Array.from({ length: 6 }, (_, index) =>
+      competitor(index + 1, {
+        name: `First Timer ${index + 1}`,
+        wcaId: null,
+        personalBests: [],
+      })
+    );
+    const experiencedCompetitors = Array.from({ length: 6 }, (_, index) =>
+      competitor(index + 7, {
+        name: `Experienced ${index + 1}`,
+      })
+    );
+
+    const wcif = runPnwRecipe([...firstTimers, ...experiencedCompetitors]);
+    const firstTimerCounts = firstTimerCountsByGroup(wcif);
+
+    expect(firstTimerCounts[3] ?? 0).toBe(0);
+    expect(Math.abs((firstTimerCounts[1] ?? 0) - (firstTimerCounts[2] ?? 0))).toBeLessThanOrEqual(
+      1
+    );
+  });
+
+  it('fills missing assignments when scrambler, runner, and competitor assignments already exist', () => {
+    const preAssignedCompetitors = [
+      competitor(1, {
+        assignments: [assignment(101, 'competitor')],
+      }),
+      competitor(2, {
+        assignments: [assignment(102, 'competitor')],
+      }),
+      competitor(3, {
+        assignments: [assignment(201, 'competitor')],
+      }),
+    ];
+    const staffAssignments = [101, 102, 201, 202].flatMap((activityId, activityIndex) =>
+      Array.from({ length: 4 }, (_, offset) => {
+        const registrantId = 4 + activityIndex * 4 + offset;
+        const assignmentCode = offset < 2 ? 'staff-scrambler' : 'staff-runner';
+
+        return competitor(registrantId, {
+          assignments: [assignment(activityId, assignmentCode)],
+        });
+      })
+    );
+    const unassignedCompetitors = Array.from({ length: 5 }, (_, index) =>
+      competitor(20 + index)
+    );
+    const initialPersons = [
+      ...preAssignedCompetitors,
+      ...staffAssignments,
+      ...unassignedCompetitors,
+    ];
+
+    const wcif = runPnwRecipe(initialPersons, { groupCount: 2, stageCount: 2 });
+
+    for (const initialPerson of initialPersons) {
+      const updatedPerson = personById(wcif, initialPerson.registrantId);
+      expect(assignmentCount(updatedPerson, 'competitor')).toBe(1);
+
+      for (const initialAssignment of initialPerson.assignments ?? []) {
+        expect(updatedPerson?.assignments).toContainEqual(initialAssignment);
+      }
+    }
+
+    for (const staffPerson of staffAssignments) {
+      const updatedPerson = personById(wcif, staffPerson.registrantId);
+      expect(assignmentCount(updatedPerson, 'staff-judge')).toBe(0);
+    }
+
+    for (const person of [...preAssignedCompetitors, ...unassignedCompetitors]) {
+      const updatedPerson = personById(wcif, person.registrantId);
+      expect(assignmentCount(updatedPerson, 'staff-judge')).toBe(1);
+    }
+  });
+
+  it('spreads the fastest competitors across different groups', () => {
+    const wcif = runPnwRecipe(
+      Array.from({ length: 9 }, (_, index) =>
+        competitor(index + 1, {
+          name: `Seeded Competitor ${index + 1}`,
+          personalBests: [personalBest(index + 1, 1000 + index)],
+        })
+      )
+    );
+
+    const fastestThreeGroups = valuesById(wcif, [1, 2, 3], (person) =>
+      competitorGroupNumber(wcif, person)
+    );
+
+    expect(new Set(fastestThreeGroups).size).toBe(3);
+  });
+
+  it('keeps repeated Luke and Michael-name variants out of the same group/stage combo', () => {
+    const lukeNames = ['Luke Adams', 'Luke Baker', 'Luke Clark', 'Luke Davis', 'Luke Evans'];
+    const michaelNames = [
+      'Michael Frost',
+      'Micheal Grant',
+      'Mikel Harris',
+      'Mykel Irwin',
+      'Mikael Jones',
+      'Mickel King',
+    ];
+    const wcif = runPnwRecipe(
+      [...lukeNames, ...michaelNames].map((name, index) => competitor(index + 1, { name })),
+      { groupCount: 3, stageCount: 2 }
+    );
+
+    const lukeCombos = valuesById(wcif, [1, 2, 3, 4, 5], (person) =>
+      competitorCombo(wcif, person)
+    );
+    const michaelCombos = valuesById(wcif, [6, 7, 8, 9, 10, 11], (person) =>
+      competitorCombo(wcif, person)
+    );
+
+    expect(new Set(lukeCombos).size).toBe(lukeCombos.length);
+    expect(new Set(michaelCombos).size).toBe(michaelCombos.length);
+  });
+});

--- a/src/store/reducers/runRecipe.test.ts
+++ b/src/store/reducers/runRecipe.test.ts
@@ -409,4 +409,23 @@ describe('runRecipe', () => {
     expect(new Set(lukeCombos).size).toBe(lukeCombos.length);
     expect(new Set(michaelCombos).size).toBe(michaelCombos.length);
   });
+
+  it('keeps duplicate first names apart even when one duplicate is in a smaller group', () => {
+    const groupOneEthan = competitor(1, {
+      name: 'Ethan Smith',
+      assignments: [assignment(101, 'competitor')],
+    });
+    const fullOtherGroups = [102, 103].flatMap((activityId, activityIndex) =>
+      Array.from({ length: 4 }, (_, offset) =>
+        competitor(2 + activityIndex * 4 + offset, {
+          assignments: [assignment(activityId, 'competitor')],
+        })
+      )
+    );
+    const unassignedEthan = competitor(20, { name: 'Ethan Jones' });
+
+    const wcif = runPnwRecipe([groupOneEthan, ...fullOtherGroups, unassignedEthan]);
+
+    expect(competitorGroupNumber(wcif, personById(wcif, 20))).not.toBe(1);
+  });
 });

--- a/src/store/reducers/runRecipe.ts
+++ b/src/store/reducers/runRecipe.ts
@@ -80,6 +80,7 @@ export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
         constraints,
         options: hydratedStep.props.options,
         maxPasses: hydratedStep.props.globalScore.maxPasses,
+        maxEvaluations: hydratedStep.props.globalScore.maxEvaluations,
       });
     }
 

--- a/src/store/reducers/runRecipe.ts
+++ b/src/store/reducers/runRecipe.ts
@@ -2,7 +2,8 @@ import { type Competition } from '@wca/helpers';
 import { Constraints, Generators } from 'wca-group-generators';
 import { findRoundActivitiesById } from '../../lib/wcif/activities';
 import { createGroupsAcrossStages } from '../../lib/wcif/groups';
-import { Recipes, fromRecipeDefinition, hydrateStep } from '../../lib/recipes';
+import { RecipeConstraints, Recipes, fromRecipeDefinition, hydrateStep } from '../../lib/recipes';
+import { shouldRunGroupStep } from '../../lib/recipes/conditions';
 import { mapIn } from '../../lib/utils/utils';
 import { type AppState } from '../initialState';
 import type { RunRecipePayload } from '../actions';
@@ -33,13 +34,16 @@ export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
 
       const constraints =
         hydratedStep.props.constraints?.map((c) => {
-          const constraintFn = (Constraints as Record<string, any>)[c.constraint];
+          const constraintFn =
+            (RecipeConstraints as Record<string, any>)[c.constraint] ??
+            (Constraints as Record<string, any>)[c.constraint];
           if (!constraintFn) {
             throw new Error(`Constraint ${c.constraint} not found`);
           }
           return {
             constraint: constraintFn,
             weight: c.weight,
+            options: c.options,
           };
         }) ?? [];
 
@@ -53,6 +57,10 @@ export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
 
     if (step.type === 'groups') {
       const roundActivities = findRoundActivitiesById(accWcif, action.roundId);
+      if (!shouldRunGroupStep(accWcif, action.roundId, roundActivities, step)) {
+        return accWcif;
+      }
+
       const roundActivitiesWithGroups = createGroupsAcrossStages(accWcif, roundActivities, {
         spreadGroupsAcrossAllStages: true,
         groups: step.props.count,

--- a/src/store/reducers/runRecipe.ts
+++ b/src/store/reducers/runRecipe.ts
@@ -2,7 +2,13 @@ import { type Competition } from '@wca/helpers';
 import { Constraints, Generators } from 'wca-group-generators';
 import { findRoundActivitiesById } from '../../lib/wcif/activities';
 import { createGroupsAcrossStages } from '../../lib/wcif/groups';
-import { RecipeConstraints, Recipes, fromRecipeDefinition, hydrateStep } from '../../lib/recipes';
+import {
+  RecipeConstraints,
+  Recipes,
+  fromRecipeDefinition,
+  hydrateStep,
+  optimizeAssignmentsGlobally,
+} from '../../lib/recipes';
 import { shouldRunGroupStep } from '../../lib/recipes/conditions';
 import { mapIn } from '../../lib/utils/utils';
 import { type AppState } from '../initialState';
@@ -47,12 +53,27 @@ export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
           };
         }) ?? [];
 
-      return generator.execute({
+      const generatedWcif = generator.execute({
         wcif: accWcif,
         roundId: action.roundId,
         ...hydratedStep.props,
         constraints,
       }) as Competition;
+
+      if (!hydratedStep.props.globalScore) {
+        return generatedWcif;
+      }
+
+      return optimizeAssignmentsGlobally({
+        beforeWcif: accWcif,
+        wcif: generatedWcif,
+        cluster: hydratedStep.props.cluster,
+        activities: hydratedStep.props.activities,
+        assignmentCode: hydratedStep.props.assignmentCode,
+        constraints,
+        options: hydratedStep.props.options,
+        maxPasses: hydratedStep.props.globalScore.maxPasses,
+      });
     }
 
     if (step.type === 'groups') {

--- a/src/store/reducers/runRecipe.ts
+++ b/src/store/reducers/runRecipe.ts
@@ -1,155 +1,28 @@
-import { type Competition } from '@wca/helpers';
-import { Constraints, Generators } from 'wca-group-generators';
-import { findRoundActivitiesById } from '../../lib/wcif/activities';
-import { createGroupsAcrossStages } from '../../lib/wcif/groups';
-import {
-  RecipeConstraints,
-  Recipes,
-  fromRecipeDefinition,
-  hydrateStep,
-  optimizeAssignmentsGlobally,
-} from '../../lib/recipes';
-import { shouldRunGroupStep } from '../../lib/recipes/conditions';
-import { mapIn } from '../../lib/utils/utils';
-import {
-  getRoundConfigExtensionData,
-  setRoundConfigExtensionData,
-} from '../../lib/wcif/extensions/delegateDashboard/delegateDashboard';
+import { runBulkRecipesOnWcif, runRecipeOnWcif } from '../../lib/recipes/runRecipeOnWcif';
 import { type AppState } from '../initialState';
 import type { RunRecipePayload, RunRecipesPayload } from '../actions';
 
-const setRoundRecipeConfig = (
-  wcif: Competition,
-  roundId: string,
-  recipeId: string
-): Competition => ({
-  ...wcif,
-  events: wcif.events.map((event) => ({
-    ...event,
-    rounds: event.rounds.map((round) => {
-      if (round.id !== roundId) {
-        return round;
-      }
-
-      return setRoundConfigExtensionData(round, {
-        ...(getRoundConfigExtensionData(round) ?? {}),
-        recipe: { id: recipeId },
-      });
-    }),
-  })),
-});
-
 /**
  * Run a built-in recipe to generate groups and/or assignments for a round.
- * Restores the legacy "recipe" workflow based on wca-group-generators.
  */
 export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
   if (!state.wcif) return state;
-
-  const wcif = state.wcif as unknown as Competition;
-  const recipeDef = Recipes.find((r) => r.id === action.recipeId);
-  if (!recipeDef) {
-    throw new Error(`Recipe ${action.recipeId} not found`);
-  }
-
-  const recipe = fromRecipeDefinition(recipeDef, { wcif, activityCode: action.roundId });
-
-  const generatedWcif = recipe.steps.reduce<Competition>((accWcif, step) => {
-    if (step.type === 'assignments') {
-      const generator = (Generators as Record<string, any>)[step.props.generator];
-      if (!generator) {
-        throw new Error(`Generator ${step.props.generator} not found`);
-      }
-
-      const hydratedStep = hydrateStep(accWcif, action.roundId, step);
-
-      const constraints =
-        hydratedStep.props.constraints?.map((c) => {
-          const constraintFn =
-            (RecipeConstraints as Record<string, any>)[c.constraint] ??
-            (Constraints as Record<string, any>)[c.constraint];
-          if (!constraintFn) {
-            throw new Error(`Constraint ${c.constraint} not found`);
-          }
-          return {
-            constraint: constraintFn,
-            weight: c.weight,
-            options: c.options,
-          };
-        }) ?? [];
-
-      const generatedWcif = generator.execute({
-        wcif: accWcif,
-        roundId: action.roundId,
-        ...hydratedStep.props,
-        constraints,
-      }) as Competition;
-
-      if (!hydratedStep.props.globalScore) {
-        return generatedWcif;
-      }
-
-      if (
-        hydratedStep.props.globalScore.maxClusterSize &&
-        hydratedStep.props.cluster.length > hydratedStep.props.globalScore.maxClusterSize
-      ) {
-        return generatedWcif;
-      }
-
-      return optimizeAssignmentsGlobally({
-        beforeWcif: accWcif,
-        wcif: generatedWcif,
-        cluster: hydratedStep.props.cluster,
-        activities: hydratedStep.props.activities,
-        assignmentCode: hydratedStep.props.assignmentCode,
-        constraints,
-        options: hydratedStep.props.options,
-        maxPasses: hydratedStep.props.globalScore.maxPasses,
-        maxEvaluations: hydratedStep.props.globalScore.maxEvaluations,
-      });
-    }
-
-    if (step.type === 'groups') {
-      const roundActivities = findRoundActivitiesById(accWcif, action.roundId);
-      if (!shouldRunGroupStep(accWcif, action.roundId, roundActivities, step)) {
-        return accWcif;
-      }
-
-      const roundActivitiesWithGroups = createGroupsAcrossStages(accWcif, roundActivities, {
-        spreadGroupsAcrossAllStages: true,
-        groups: step.props.count,
-      });
-
-      return {
-        ...accWcif,
-        schedule: mapIn(accWcif.schedule, 'venues', (venue) =>
-          mapIn(venue, 'rooms', (room) =>
-            mapIn(room, 'activities', (activity) =>
-              roundActivitiesWithGroups.find((ra) => ra.id === activity.id)
-                ? (roundActivitiesWithGroups.find((ra) => ra.id === activity.id) as any)
-                : activity
-            )
-          )
-        ),
-      } as Competition;
-    }
-
-    return accWcif;
-  }, wcif);
-
-  const updatedWcif = setRoundRecipeConfig(generatedWcif, action.roundId, action.recipeId);
 
   return {
     ...state,
     needToSave: true,
     changedKeys: new Set([...state.changedKeys, 'schedule', 'persons', 'events']),
-    wcif: updatedWcif,
+    wcif: runRecipeOnWcif(state.wcif, action),
   };
 }
 
 export function runRecipes(state: AppState, action: RunRecipesPayload): AppState {
-  return action.roundIds.reduce<AppState>(
-    (accState, roundId) => runRecipe(accState, { roundId, recipeId: action.recipeId }),
-    state
-  );
+  if (!state.wcif) return state;
+
+  return {
+    ...state,
+    needToSave: true,
+    changedKeys: new Set([...state.changedKeys, 'schedule', 'persons', 'events']),
+    wcif: runBulkRecipesOnWcif(state.wcif, action),
+  };
 }

--- a/src/store/reducers/runRecipe.ts
+++ b/src/store/reducers/runRecipe.ts
@@ -64,6 +64,13 @@ export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
         return generatedWcif;
       }
 
+      if (
+        hydratedStep.props.globalScore.maxClusterSize &&
+        hydratedStep.props.cluster.length > hydratedStep.props.globalScore.maxClusterSize
+      ) {
+        return generatedWcif;
+      }
+
       return optimizeAssignmentsGlobally({
         beforeWcif: accWcif,
         wcif: generatedWcif,

--- a/src/store/reducers/runRecipe.ts
+++ b/src/store/reducers/runRecipe.ts
@@ -11,8 +11,33 @@ import {
 } from '../../lib/recipes';
 import { shouldRunGroupStep } from '../../lib/recipes/conditions';
 import { mapIn } from '../../lib/utils/utils';
+import {
+  getRoundConfigExtensionData,
+  setRoundConfigExtensionData,
+} from '../../lib/wcif/extensions/delegateDashboard/delegateDashboard';
 import { type AppState } from '../initialState';
-import type { RunRecipePayload } from '../actions';
+import type { RunRecipePayload, RunRecipesPayload } from '../actions';
+
+const setRoundRecipeConfig = (
+  wcif: Competition,
+  roundId: string,
+  recipeId: string
+): Competition => ({
+  ...wcif,
+  events: wcif.events.map((event) => ({
+    ...event,
+    rounds: event.rounds.map((round) => {
+      if (round.id !== roundId) {
+        return round;
+      }
+
+      return setRoundConfigExtensionData(round, {
+        ...(getRoundConfigExtensionData(round) ?? {}),
+        recipe: { id: recipeId },
+      });
+    }),
+  })),
+});
 
 /**
  * Run a built-in recipe to generate groups and/or assignments for a round.
@@ -29,7 +54,7 @@ export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
 
   const recipe = fromRecipeDefinition(recipeDef, { wcif, activityCode: action.roundId });
 
-  const updatedWcif = recipe.steps.reduce<Competition>((accWcif, step) => {
+  const generatedWcif = recipe.steps.reduce<Competition>((accWcif, step) => {
     if (step.type === 'assignments') {
       const generator = (Generators as Record<string, any>)[step.props.generator];
       if (!generator) {
@@ -112,10 +137,19 @@ export function runRecipe(state: AppState, action: RunRecipePayload): AppState {
     return accWcif;
   }, wcif);
 
+  const updatedWcif = setRoundRecipeConfig(generatedWcif, action.roundId, action.recipeId);
+
   return {
     ...state,
     needToSave: true,
     changedKeys: new Set([...state.changedKeys, 'schedule', 'persons', 'events']),
     wcif: updatedWcif,
   };
+}
+
+export function runRecipes(state: AppState, action: RunRecipesPayload): AppState {
+  return action.roundIds.reduce<AppState>(
+    (accState, roundId) => runRecipe(accState, { roundId, recipeId: action.recipeId }),
+    state
+  );
 }


### PR DESCRIPTION
## Summary
- add recipe-local constraints for PNW assignment behavior
- add delegate/organizer competitor assignment step to the main PNW recipe
- add behavior tests for staff wraparound, key-staff spreading, first-timer distribution, speed balancing, and similar first-name avoidance

## Validation
- yarn test src/lib/recipes/constraints.test.ts src/store/reducers/runRecipe.test.ts
- yarn check:type
- pre-push hook: tsc --noEmit and eslint ./ passed with warnings only

## Note
- Full pre-commit Vitest suite currently fails in src/store/actions.test.ts on an unrelated expectation for patchWcif payload including formatVersion.