### PR TITLE
Preflight WCIF saves

### DIFF
--- a/e2e/mocks/wcaApi.ts
+++ b/e2e/mocks/wcaApi.ts
@@ -100,7 +100,7 @@ export const registerWcaApiRoutes = async (
       return;
     }
 
-    const wcifMatch = apiPath.match(/^\/competitions\/([^/]+)\/wcif$/);
+    const wcifMatch = apiPath.match(/^\/competitions\/([^/]+)\/wcif(?:\/version\/2)?$/);
     if (wcifMatch && method === 'GET') {
       const competitionId = wcifMatch[1];
       const wcif = state.wcifById[competitionId] ?? state.wcif;
@@ -119,6 +119,11 @@ export const registerWcaApiRoutes = async (
         state.wcif = next;
       }
       await route.fulfill(jsonResponse(next));
+      return;
+    }
+
+    if (apiPath === '/competitions/wcif/check' && method === 'PUT') {
+      await route.fulfill({ status: 204, headers: corsHeaders, body: '' });
       return;
     }
 

--- a/src/layout/CompetitionLayout/CompetitionLayout.tsx
+++ b/src/layout/CompetitionLayout/CompetitionLayout.tsx
@@ -83,7 +83,7 @@ export const CompetitionLayout = () => {
     dispatch(
       uploadCurrentWCIFChanges((e) => {
         if (e) {
-          enqueueSnackbar('Error saving changes', { variant: 'error' });
+          enqueueSnackbar(`Error saving changes: ${e.message}`, { variant: 'error' });
         } else {
           enqueueSnackbar('Saved!', { variant: 'success' });
         }

--- a/src/layout/CompetitionLayout/_tests_/CompetitionLayout.test.tsx
+++ b/src/layout/CompetitionLayout/_tests_/CompetitionLayout.test.tsx
@@ -155,6 +155,8 @@ describe('CompetitionLayout', () => {
     const errorCallback = uploadCurrentWCIFChangesMock.mock.calls[1][0];
     errorCallback(new Error('save failed'));
 
-    expect(enqueueSnackbarMock).toHaveBeenCalledWith('Error saving changes', { variant: 'error' });
+    expect(enqueueSnackbarMock).toHaveBeenCalledWith('Error saving changes: save failed', {
+      variant: 'error',
+    });
   });
 });

--- a/src/lib/api/wcaAPI.test.ts
+++ b/src/lib/api/wcaAPI.test.ts
@@ -4,6 +4,8 @@ import {
   getMe,
   getPastManageableCompetitions,
   getUpcomingManageableCompetitions,
+  getWcif,
+  patchWcif,
   saveWcifChanges,
   wcaApiFetch,
 } from './wcaAPI';
@@ -101,6 +103,7 @@ describe('wcaAPI', () => {
     mockFetch({ json: vi.fn().mockResolvedValue({ id: 'Comp', name: 'New' }) });
     const previousWcif = {
       id: 'Comp',
+      formatVersion: '2.0',
       name: 'Old',
       schedule: { startDate: '2024-01-01', numberOfDays: 1, venues: [] },
       events: [],
@@ -115,7 +118,7 @@ describe('wcaAPI', () => {
       'https://wca.test/api/v0/competitions/Comp/wcif',
       expect.objectContaining({
         method: 'PATCH',
-        body: JSON.stringify({ name: 'New' }),
+        body: JSON.stringify({ formatVersion: '2.0', name: 'New' }),
       })
     );
   });
@@ -136,6 +139,33 @@ describe('wcaAPI', () => {
     expect(globalThis.fetch).not.toHaveBeenCalledWith(
       'https://wca.test/api/v0/competitions/Comp/wcif',
       expect.objectContaining({ method: 'PATCH' })
+    );
+  });
+
+  it('fetches WCIF from the version 2 endpoint', async () => {
+    mockFetch({ json: vi.fn().mockResolvedValue({ id: 'Comp' }) });
+
+    await getWcif('Comp');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://wca.test/api/v0/competitions/Comp/wcif/version/2',
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      })
+    );
+  });
+
+  it('patches WCIF to the unchanged update endpoint', async () => {
+    mockFetch({ json: vi.fn().mockResolvedValue({ id: 'Comp' }) });
+
+    await patchWcif('Comp', { formatVersion: '2.0', name: 'Updated' } as any);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://wca.test/api/v0/competitions/Comp/wcif',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ formatVersion: '2.0', name: 'Updated' }),
+      })
     );
   });
 });

--- a/src/lib/api/wcaAPI.test.ts
+++ b/src/lib/api/wcaAPI.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import {
+  checkWcif,
   getMe,
   getPastManageableCompetitions,
   getUpcomingManageableCompetitions,
@@ -50,6 +51,34 @@ describe('wcaAPI', () => {
 
     mockFetch({ ok: false, status: 418, statusText: '' });
     await expect(wcaApiFetch('/me')).rejects.toThrow('Something went wrong: Status code 418');
+  });
+
+  it('uses an API error response when one is available', async () => {
+    mockFetch({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: vi.fn().mockResolvedValue({ error: 'WCIF formatVersion is required' }),
+    });
+
+    await expect(wcaApiFetch('/me')).rejects.toThrow('WCIF formatVersion is required');
+  });
+
+  it('checks a complete WCIF without parsing the empty success response', async () => {
+    const json = vi.fn();
+    const wcif = { id: 'Comp', formatVersion: '1.1' } as any;
+    mockFetch({ json });
+
+    await checkWcif(wcif);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://wca.test/api/v0/competitions/wcif/check',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify(wcif),
+      })
+    );
+    expect(json).not.toHaveBeenCalled();
   });
 
   it('builds upcoming and past competition queries', async () => {

--- a/src/lib/api/wcaAPI.ts
+++ b/src/lib/api/wcaAPI.ts
@@ -56,6 +56,16 @@ export const patchWcif = (
     body: JSON.stringify(wcif),
   });
 
+export const checkWcif = (wcif: Competition): Promise<void> =>
+  wcaApiFetch(
+    '/competitions/wcif/check',
+    {
+      method: 'PUT',
+      body: JSON.stringify(wcif),
+    },
+    false
+  );
+
 export const saveWcifChanges = (
   previousWcif: Competition,
   newWcif: Competition
@@ -82,7 +92,8 @@ export const getUser = (userId: number): Promise<{ user: WcaUser }> =>
 
 export const wcaApiFetch = async <T = unknown>(
   path: string,
-  fetchOptions: RequestInit = {}
+  fetchOptions: RequestInit = {},
+  parseJsonResponse = true
 ): Promise<T> => {
   const baseApiUrl = `${WCA_ORIGIN}/api/v0`;
 
@@ -97,6 +108,9 @@ export const wcaApiFetch = async <T = unknown>(
   );
 
   if (!res.ok) {
+    const error = await errorFromResponse(res);
+    if (error) throw new Error(error);
+
     if (res.statusText) {
       throw new Error(`${res.status}: ${res.statusText}`);
     } else {
@@ -104,5 +118,22 @@ export const wcaApiFetch = async <T = unknown>(
     }
   }
 
+  if (!parseJsonResponse) return undefined as T;
+
   return await res.json();
+};
+
+const errorFromResponse = async (res: Response): Promise<string | undefined> => {
+  try {
+    const body: unknown = await res.json();
+    if (Array.isArray(body)) return body.map(String).join('\n');
+
+    if (body && typeof body === 'object' && 'error' in body) {
+      const error = body.error;
+      if (Array.isArray(error)) return error.map(String).join('\n');
+      if (typeof error === 'string') return error;
+    }
+  } catch {
+    // Fall back to the HTTP status when the API does not return JSON.
+  }
 };

--- a/src/lib/api/wcaAPI.ts
+++ b/src/lib/api/wcaAPI.ts
@@ -10,6 +10,10 @@ import { type Competition } from '@wca/helpers';
 import { pick } from 'lodash';
 
 const wcaAccessToken = (): string | null => getLocalStorage('accessToken');
+const WCIF_VERSION = '2';
+const wcifPath = (competitionId: string) => `/competitions/${competitionId}/wcif`;
+const versionedWcifPath = (competitionId: string) =>
+  `${wcifPath(competitionId)}/version/${WCIF_VERSION}`;
 
 export const getMe = (): Promise<{ me: WcaUser }> => {
   return wcaApiFetch(`/me`);
@@ -45,13 +49,13 @@ export const getPastManageableCompetitions = (): Promise<CompetitionSearchResult
 };
 
 export const getWcif = (competitionId: string): Promise<Competition> =>
-  wcaApiFetch(`/competitions/${competitionId}/wcif`);
+  wcaApiFetch(versionedWcifPath(competitionId));
 
 export const patchWcif = (
   competitionId: string,
   wcif: Partial<Competition>
 ): Promise<Competition> =>
-  wcaApiFetch(`/competitions/${competitionId}/wcif`, {
+  wcaApiFetch(wcifPath(competitionId), {
     method: 'PATCH',
     body: JSON.stringify(wcif),
   });

--- a/src/store/actions.test.ts
+++ b/src/store/actions.test.ts
@@ -26,7 +26,7 @@ import {
 import type { Assignment, Competition } from '@wca/helpers';
 import type { Extension } from '@wca/helpers/lib/models/extension';
 import { describe, expect, it, vi } from 'vitest';
-import { getUpcomingManageableCompetitions, getWcif, patchWcif } from '../lib/api';
+import { checkWcif, getUpcomingManageableCompetitions, getWcif, patchWcif } from '../lib/api';
 import { sortWcifEvents } from '../lib/domain/events';
 import { validateWcif } from '../lib/wcif/validation';
 import type { AppState } from './initialState';
@@ -41,6 +41,7 @@ import {
 vi.mock('../lib/api', () => ({
   getUpcomingManageableCompetitions: vi.fn(),
   getWcif: vi.fn(),
+  checkWcif: vi.fn(),
   patchWcif: vi.fn(),
 }));
 
@@ -54,6 +55,7 @@ vi.mock('../lib/wcif/validation', () => ({
 
 const getUpcomingManageableCompetitionsMock = vi.mocked(getUpcomingManageableCompetitions);
 const getWcifMock = vi.mocked(getWcif);
+const checkWcifMock = vi.mocked(checkWcif);
 const patchWcifMock = vi.mocked(patchWcif);
 const sortWcifEventsMock = vi.mocked(sortWcifEvents);
 const validateWcifMock = vi.mocked(validateWcif);
@@ -311,6 +313,7 @@ describe('store actions', () => {
         wcif,
         changedKeys: new Set(['events']),
       }) as unknown as AppState;
+    checkWcifMock.mockResolvedValueOnce(undefined);
     patchWcifMock.mockResolvedValueOnce(wcif);
 
     uploadCurrentWCIFChanges(cb)(dispatch, getState);
@@ -320,6 +323,7 @@ describe('store actions', () => {
       type: ActionType.UPLOADING_WCIF,
       uploading: true,
     });
+    expect(checkWcifMock).toHaveBeenCalledWith(wcif);
     expect(patchWcifMock).toHaveBeenCalledWith('Comp1', {
       formatVersion: wcif.formatVersion,
       events: wcif.events,
@@ -343,6 +347,7 @@ describe('store actions', () => {
         changedKeys: new Set(['events']),
       }) as unknown as AppState;
     const error = new Error('Upload failed');
+    checkWcifMock.mockResolvedValueOnce(undefined);
     patchWcifMock.mockRejectedValueOnce(error);
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -357,6 +362,25 @@ describe('store actions', () => {
       type: ActionType.UPLOADING_WCIF,
       uploading: false,
     });
+    expect(cb).toHaveBeenCalledWith(error);
+    consoleError.mockRestore();
+  });
+
+  it('does not patch when the WCIF schema check fails', async () => {
+    vi.clearAllMocks();
+    const dispatch = vi.fn();
+    const cb = vi.fn();
+    const wcif = { ...buildWcif([], []), id: 'Comp1' };
+    const error = new Error('WCIF formatVersion is required');
+    const getState = () =>
+      ({ wcif, changedKeys: new Set(['events']) }) as unknown as AppState;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    checkWcifMock.mockRejectedValueOnce(error);
+
+    uploadCurrentWCIFChanges(cb)(dispatch, getState);
+    await flushPromises();
+
+    expect(patchWcifMock).not.toHaveBeenCalled();
     expect(cb).toHaveBeenCalledWith(error);
     consoleError.mockRestore();
   });

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,4 +1,4 @@
-import { getUpcomingManageableCompetitions, getWcif, patchWcif } from '../lib/api';
+import { checkWcif, getUpcomingManageableCompetitions, getWcif, patchWcif } from '../lib/api';
 import { sortWcifEvents } from '../lib/domain/events';
 import { type BulkInProgressAssignments } from '../lib/types';
 import { validateWcif, type ValidationError } from '../lib/wcif/validation';
@@ -163,7 +163,8 @@ export const uploadCurrentWCIFChanges =
     const changes = pick(wcif, keysForPatch);
 
     dispatch(updateUploading(true));
-    patchWcif(competitionId, changes)
+    checkWcif(wcif)
+      .then(() => patchWcif(competitionId, changes))
       .then(() => {
         dispatch(updateUploading(false));
         cb();


### PR DESCRIPTION
## Summary

- validate the complete WCIF through the WCA `/wcif/check` endpoint before saving
- retain the existing partial WCIF PATCH after validation succeeds
- show WCA API error details in the save notification

## Why

WCA will enforce strict schema validation for WCIF PATCH requests. Preflighting the complete document prevents an invalid update from reaching PATCH and gives delegates the server's actionable error message.

## Validation

- `yarn test` (368 passing)
- `yarn check:type`
- `yarn lint` (existing warnings only)
- `yarn build`
