### PR TITLE
Fix WCIF v2 personal best production failures

### DIFF
--- a/src/components/GroupCard.tsx
+++ b/src/components/GroupCard.tsx
@@ -11,7 +11,7 @@ import {
   activityDurationString,
   type ActivityWithParent,
 } from '../lib/domain/activities';
-import { mayMakeCutoff, mayMakeTimeLimit } from '../lib/domain/persons';
+import { getPersonalBestValue, mayMakeCutoff, mayMakeTimeLimit } from '../lib/domain/persons';
 import { useAppSelector } from '../store';
 import { selectPersonsAssignedToActivitiyId } from '../store/selectors';
 import ConfigureGroupDialog from '../dialogs/ConfigureGroupDialog';
@@ -124,7 +124,7 @@ const GroupCard = ({ groupActivity }: GroupCardProps) => {
           const pr = person.personalBests?.find(
             (pb) => pb.eventId === eventId && pb.type === 'average'
           );
-          return pr?.best;
+          return pr ? getPersonalBestValue(pr) : undefined;
         })
         .filter((pr) => !!pr) as number[],
     [competitors, eventId]

--- a/src/lib/api/wcaAPI.test.ts
+++ b/src/lib/api/wcaAPI.test.ts
@@ -83,6 +83,46 @@ describe('wcaAPI', () => {
     expect(json).not.toHaveBeenCalled();
   });
 
+  it('omits read-only v2 personal bests from the WCIF check payload', async () => {
+    const wcif = {
+      formatVersion: '2.1.1',
+      persons: [{ registrantId: 1, personalBests: [{ eventId: '333', value: 1000 }] }],
+    } as any;
+    mockFetch({});
+
+    await checkWcif(wcif);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://wca.test/api/v0/competitions/wcif/check',
+      expect.objectContaining({
+        body: JSON.stringify({
+          formatVersion: '2.1.1',
+          persons: [{ registrantId: 1 }],
+        }),
+      })
+    );
+  });
+
+  it('omits read-only v2 personal bests from patch payloads', async () => {
+    const wcif = {
+      formatVersion: '2.1.1',
+      persons: [{ registrantId: 1, personalBests: [{ eventId: '333', value: 1000 }] }],
+    } as any;
+    mockFetch({ json: vi.fn().mockResolvedValue({}) });
+
+    await patchWcif('Comp', wcif);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://wca.test/api/v0/competitions/Comp/wcif',
+      expect.objectContaining({
+        body: JSON.stringify({
+          formatVersion: '2.1.1',
+          persons: [{ registrantId: 1 }],
+        }),
+      })
+    );
+  });
+
   it('builds upcoming and past competition queries', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(0);
     mockFetch({ json: vi.fn().mockResolvedValue([]) });

--- a/src/lib/api/wcaAPI.ts
+++ b/src/lib/api/wcaAPI.ts
@@ -15,6 +15,21 @@ const wcifPath = (competitionId: string) => `/competitions/${competitionId}/wcif
 const versionedWcifPath = (competitionId: string) =>
   `${wcifPath(competitionId)}/version/${WCIF_VERSION}`;
 
+/**
+ * Personal bests are read-only data. The v2 endpoint returns them, but the
+ * current WCIF checker does not accept them in a submitted v2 payload.
+ */
+const withoutV2PersonalBests = <T extends Partial<Competition>>(wcif: T): T => {
+  if (!wcif.formatVersion?.startsWith('2.') || !wcif.persons) {
+    return wcif;
+  }
+
+  return {
+    ...wcif,
+    persons: wcif.persons.map(({ personalBests: _personalBests, ...person }) => person),
+  } as T;
+};
+
 export const getMe = (): Promise<{ me: WcaUser }> => {
   return wcaApiFetch(`/me`);
 };
@@ -57,7 +72,7 @@ export const patchWcif = (
 ): Promise<Competition> =>
   wcaApiFetch(wcifPath(competitionId), {
     method: 'PATCH',
-    body: JSON.stringify(wcif),
+    body: JSON.stringify(withoutV2PersonalBests(wcif)),
   });
 
 export const checkWcif = (wcif: Competition): Promise<void> =>
@@ -65,7 +80,7 @@ export const checkWcif = (wcif: Competition): Promise<void> =>
     '/competitions/wcif/check',
     {
       method: 'PUT',
-      body: JSON.stringify(wcif),
+      body: JSON.stringify(withoutV2PersonalBests(wcif)),
     },
     false
   );

--- a/src/lib/domain/persons.test.ts
+++ b/src/lib/domain/persons.test.ts
@@ -7,6 +7,7 @@ import {
   shouldBeInRound,
   personsShouldBeInRound,
   findPR,
+  getPersonalBestValue,
   byPsychsheet,
   byResult,
   addAssignmentsToPerson,
@@ -305,6 +306,34 @@ describe('findPR', () => {
 
     expect(findPR(personalBests, '444', 'single')).toBeUndefined();
     expect(findPR(personalBests, '333', 'average')).toBeUndefined();
+  });
+});
+
+describe('getPersonalBestValue', () => {
+  it('reads the v1 best field', () => {
+    expect(
+      getPersonalBestValue({
+        eventId: '333',
+        type: 'single',
+        best: 1000,
+        worldRanking: 1,
+        continentalRanking: 1,
+        nationalRanking: 1,
+      })
+    ).toBe(1000);
+  });
+
+  it('reads the v2 value field', () => {
+    expect(
+      getPersonalBestValue({
+        eventId: '333',
+        type: 'single',
+        value: 1000,
+        worldRanking: 1,
+        continentalRanking: 1,
+        nationalRanking: 1,
+      } as never)
+    ).toBe(1000);
   });
 });
 

--- a/src/lib/domain/persons.ts
+++ b/src/lib/domain/persons.ts
@@ -2,6 +2,7 @@ import { parseActivityCode } from './activities';
 import {
   type Activity,
   type Assignment,
+  type AttemptResult,
   type Event,
   type EventId,
   type Person,
@@ -76,6 +77,14 @@ export const assignedInGroupsForRoles =
 
 export const findPR = (personalBests: PersonalBest[], eventId: EventId, type: RankingType) =>
   personalBests.find((pr) => pr.eventId === eventId && pr.type === type);
+
+type V2PersonalBest = Omit<PersonalBest, 'best'> & { value: AttemptResult };
+
+/**
+ * WCIF v1 calls this field `best`. WCIF v2 calls it `value`.
+ */
+export const getPersonalBestValue = (personalBest: PersonalBest | V2PersonalBest) =>
+  'value' in personalBest ? personalBest.value : personalBest.best;
 
 /**
  * Comparator for array.sort
@@ -215,7 +224,7 @@ export const mayMakeTimeLimit = (eventId: EventId, round?: Round, persons?: Pers
         return false;
       }
 
-      return PR.best <= timeLimit.centiseconds;
+      return getPersonalBestValue(PR) <= timeLimit.centiseconds;
     }) || []
   );
 };
@@ -233,7 +242,7 @@ export const mayMakeCutoff = (eventId: EventId, round?: Round, persons?: Person[
         return false;
       }
 
-      return PR.best <= cutoff.attemptResult;
+      return getPersonalBestValue(PR) <= cutoff.attemptResult;
     }) || []
   );
 };

--- a/src/lib/wcif/persons.ts
+++ b/src/lib/wcif/persons.ts
@@ -1,6 +1,6 @@
 import { parseActivityCode } from '../domain/activities/activityCode';
 import { roundFormatById } from '../domain/events';
-import { findPR } from '../domain/persons';
+import { findPR, getPersonalBestValue } from '../domain/persons';
 import { type Competition, type Person, type AttemptResult } from '@wca/helpers';
 
 /** WCIF Person Lookup Functions */
@@ -79,8 +79,8 @@ export const getSeedResult = (
     const single = findPR(person.personalBests || [], eventId, 'single');
 
     return {
-      average: average?.best,
-      single: single?.best,
+      average: average ? getPersonalBestValue(average) : undefined,
+      single: single ? getPersonalBestValue(single) : undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

- Omit read-only `personalBests` from WCIF v2 validation and save payloads.
- Support both v1 `best` and v2 `value` personal-best fields.

## Root cause

The production WCIF v2.1.1 endpoint returns `value`, but the live WCIF checker rejects `personalBests` in submitted v2 payloads. The full preflight check then failed before saves.

## Validation

- `yarn test`
- `yarn check:type`
- `yarn lint`
- `yarn build`
- Live WCIF v2 check returned HTTP 200 after removing read-only personal bests.

The unrelated existing `package.json` change remains unstaged.